### PR TITLE
ENG-5715 fix jitpack icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Neuro-ID Mobile SDK for Android Demo
-[![Release](https://jitpack.io/v/User/Repo.svg)]
-(https://jitpack.io/#Neuro-ID/neuroid-android-sdk)
-
+[![](https://jitpack.io/v/Neuro-ID/neuroid-android-sdk.svg)](https://jitpack.io/#Neuro-ID/neuroid-android-sdk)
 
 Neuro-ID's Mobile SDK makes it simple to embed behavioral analytics inside your mobile app. With a few lines of code, you can connect your app with the Neuro-ID platform and make informed decisions about your users.
 


### PR DESCRIPTION
# ENG-5715 fix jitpack icon
This PR fixes the jitpack icon URL in the documentation.

## [ENG-5715](https://neuro-id.atlassian.net/browse/ENG-5715)

## Type of change
- Fixed broken link (non-breaking change)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests if it is a core feature.

[ENG-5715]: https://neuro-id.atlassian.net/browse/ENG-5715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ