### PR TITLE
revert accidental push change from master to develop back to master

### DIFF
--- a/.github/workflows/github-actions-master-push-assamble.yml
+++ b/.github/workflows/github-actions-master-push-assamble.yml
@@ -2,7 +2,7 @@ name: Uploading React and Sandbox Projects (Master)
 on:
   push:
     branches:
-      - develop
+      - master
     paths-ignore:
       - app/libs
 


### PR DESCRIPTION
I somehow changed the github-actions-master-push-assemble.yml script to point to develop instead of master. The intention was to change this on my fork of neuroid-android-sdk but I think I specified the incorrect origin during the push. Not sure how I was able to push the change directly to master without a PR though. This PR here will fix that.