### PR TITLE
ENG-5952 duplicate event edittext fix and text watcher cut/paste  fix 

### DIFF
--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -90,11 +90,14 @@ class NIDActivityCallbacks : ActivityLifecycleCallbacks {
      * Option for customers to force start with Activity
      */
     public fun forceStart(activity: Activity) {
-        registerTargetFromScreen(
-            activity,
-            activityOrFragment = "activity",
-            parent = activity::class.java.simpleName
-        )
+        if (!NeuroID.ACTIVE_REGISTERED_TARGETS.contains(activity::class.java.simpleName)) {
+            NeuroID.ACTIVE_REGISTERED_TARGETS.add(activity::class.java.simpleName)
+            registerTargetFromScreen(
+                activity,
+                activityOrFragment = "activity",
+                parent = activity::class.java.simpleName
+            )
+        }
     }
 
     override fun onActivityStarted(activity: Activity) {
@@ -119,8 +122,10 @@ class NIDActivityCallbacks : ActivityLifecycleCallbacks {
         val hasFragments = fragManager?.hasFragments() ?: false
 
         if (existActivity) {
-            if (hasFragments.not() && cameBackFromBehind.not()) {
+            if (!NeuroID.ACTIVE_REGISTERED_TARGETS.contains(currentActivityName)
+                    && hasFragments.not() && cameBackFromBehind.not()) {
 //                NIDLog.d("NID--Activity", "Activity - POST Started - Exist & fragments")
+                NeuroID.ACTIVE_REGISTERED_TARGETS.contains(currentActivityName)
                 registerTargetFromScreen(
                     activity,
                     registerListeners = false,
@@ -133,8 +138,9 @@ class NIDActivityCallbacks : ActivityLifecycleCallbacks {
             }
         } else {
             listActivities.add(currentActivityName)
-            if (hasFragments.not()) {
+            if (hasFragments.not() && !NeuroID.ACTIVE_REGISTERED_TARGETS.contains(currentActivityName)) {
 //                NIDLog.d("NID--Activity", "Activity - POST Started - NOT Exist & fragment")
+                NeuroID.ACTIVE_REGISTERED_TARGETS.add(currentActivityName)
                 registerTargetFromScreen(
                     activity,
                     wasChanged.not(),

--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDFragmentCallbacks.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDFragmentCallbacks.kt
@@ -80,7 +80,9 @@ class NIDFragmentCallbacks(
 
         // TODO skip on force start
         // On clients where we have trouble starting the registration do a force start
-        if (NeuroID.getInstance()?.getForceStart() == true) {
+        if (!NeuroID.ACTIVE_REGISTERED_TARGETS.contains(f::class.java.simpleName)
+                && NeuroID.getInstance()?.getForceStart() == true) {
+            NeuroID.ACTIVE_REGISTERED_TARGETS.add(f::class.java.simpleName)
             registerTargetFromScreen(
                 f.requireActivity(),
                 true,
@@ -95,12 +97,15 @@ class NIDFragmentCallbacks(
 //                "NID-Activity",
 //                "Fragment - Resumed - REGISTER TARGET ${f::class.java.simpleName}"
 //            )
-            registerTargetFromScreen(
-                f.requireActivity(),
-                _isChangeOrientation.not(),
-                activityOrFragment = "fragment",
-                parent = f::class.java.simpleName
-            )
+            if (!NeuroID.ACTIVE_REGISTERED_TARGETS.contains(f::class.java.simpleName)) {
+                NeuroID.ACTIVE_REGISTERED_TARGETS.add(f::class.java.simpleName)
+                registerTargetFromScreen(
+                    f.requireActivity(),
+                    _isChangeOrientation.not(),
+                    activityOrFragment = "fragment",
+                    parent = f::class.java.simpleName
+                )
+            }
             _isChangeOrientation = false
         } else {
 //            NIDLog.d("NID-Activity", "Fragment - Resumed - blacklisted ${f::class.java.simpleName}")

--- a/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
@@ -43,7 +43,6 @@ class NeuroID private constructor(
 
     private var forceStart: Boolean? = null
 
-
     private var metaData: NIDMetaData? = null
 
     internal var verifyIntegrationHealth: Boolean = false
@@ -80,7 +79,7 @@ class NeuroID private constructor(
 
     companion object {
         const val ENDPOINT_PRODUCTION = "https://receiver.neuroid.cloud/c"
-
+        val ACTIVE_REGISTERED_TARGETS = mutableSetOf<String>()
         private var singleton: NeuroID? = null
 
         @JvmStatic

--- a/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
@@ -43,6 +43,7 @@ class NeuroID private constructor(
 
     private var forceStart: Boolean? = null
 
+
     private var metaData: NIDMetaData? = null
 
     internal var verifyIntegrationHealth: Boolean = false
@@ -79,6 +80,7 @@ class NeuroID private constructor(
 
     companion object {
         const val ENDPOINT_PRODUCTION = "https://receiver.neuroid.cloud/c"
+
         val ACTIVE_REGISTERED_TARGETS = mutableSetOf<String>()
         private var singleton: NeuroID? = null
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
@@ -1,5 +1,6 @@
 package com.neuroid.tracker.utils
 
+import android.R
 import android.content.ClipboardManager
 import android.content.Context
 import android.text.Editable
@@ -43,7 +44,8 @@ class NIDTextWatcher(
         val clipData = clipboard?.primaryClip
         if (clipData != null && clipData.itemCount > 0) {
             val pastedText = clipData.getItemAt(0).text
-            if (sequence.toString().contains(pastedText)) {
+            val pasteCount = pastedText.length
+            if (sequence.toString().contains(pastedText) && (pasteCount == count)) {
                 // The change is likely due to a paste operation
 
                 val ts = System.currentTimeMillis()

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
@@ -1,6 +1,5 @@
 package com.neuroid.tracker.utils
 
-import android.R
 import android.content.ClipboardManager
 import android.content.Context
 import android.text.Editable
@@ -44,6 +43,12 @@ class NIDTextWatcher(
         val clipData = clipboard?.primaryClip
         if (clipData != null && clipData.itemCount > 0) {
             val pastedText = clipData.getItemAt(0).text
+            // we will get the length of the pasted text and see if this matches the
+            // the current text count, if not the same, this is not a paste but text typed
+            // by the user (1 char) and should not send a paste event. if however the paste
+            // is one character, the paste will show on every text update until activity/fragment
+            // is killed or a larger cut/paste is done.
+            // TODO think about a way to check the actual text instead of just the count
             val pasteCount = pastedText.length
             if (sequence.toString().contains(pastedText) && (pasteCount == count)) {
                 // The change is likely due to a paste operation

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -16,6 +16,7 @@ import org.json.JSONObject
 
 
 class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
+
     private var auxOrientation = -1
     private var activitiesStarted = 1
     private var listActivities = ArrayList<String>()
@@ -89,13 +90,16 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
 
 
     public fun forceStart(activity: Activity) {
-        registerTargetFromScreen(
-            activity,
-            registerTarget = true,
-            registerListeners = true,
-            activityOrFragment = "activity",
-            parent = activity::class.java.name
-        )
+        if (!ACTIVE_REGISTERED_TARGETS.contains(activity::class.java.name)) {
+            ACTIVE_REGISTERED_TARGETS.add(activity::class.java.name)
+            registerTargetFromScreen(
+                activity,
+                registerTarget = true,
+                registerListeners = true,
+                activityOrFragment = "activity",
+                parent = activity::class.java.name
+            )
+        }
     }
 
     override fun onActivityStarted(activity: Activity) {

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDFragmentCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDFragmentCallbacks.kt
@@ -51,7 +51,9 @@ class NIDFragmentCallbacks : FragmentManager.FragmentLifecycleCallbacks() {
 
             if (listFragment.contains(fragName)) {
                 val index = listFragment.indexOf(fragName)
-                if (index != listFragment.size - 1) {
+                if (index != listFragment.size - 1
+                        && !NIDCallbackUtils.ACTIVE_REGISTERED_TARGETS.contains(f::class.java.simpleName)) {
+                    NIDCallbackUtils.ACTIVE_REGISTERED_TARGETS.add(f::class.java.simpleName)
                     listFragment.removeLast()
                     registerTargetFromScreen(
                         f.requireActivity(),
@@ -63,13 +65,16 @@ class NIDFragmentCallbacks : FragmentManager.FragmentLifecycleCallbacks() {
                 }
             } else {
                 listFragment.add(fragName)
-                registerTargetFromScreen(
-                    f.requireActivity(),
-                    registerTarget = true,
-                    registerListeners = true,
-                    activityOrFragment = "fragment",
-                    parent = f::class.java.simpleName
-                )
+                if (!NIDCallbackUtils.ACTIVE_REGISTERED_TARGETS.contains(f::class.java.simpleName)) {
+                    NIDCallbackUtils.ACTIVE_REGISTERED_TARGETS.add(f::class.java.simpleName)
+                    registerTargetFromScreen(
+                        f.requireActivity(),
+                        registerTarget = true,
+                        registerListeners = true,
+                        activityOrFragment = "fragment",
+                        parent = f::class.java.simpleName
+                    )
+                }
             }
         }
     }

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/utils/NIDCallbackUtils.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/utils/NIDCallbackUtils.kt
@@ -1,0 +1,7 @@
+package com.neuroid.tracker.utils
+
+class NIDCallbackUtils {
+    companion object {
+        val ACTIVE_REGISTERED_TARGETS = mutableSetOf<String>()
+    }
+}

--- a/NeuroID/src/release/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/release/java/com/neuroid/tracker/NeuroID.kt
@@ -80,7 +80,7 @@ class NeuroID private constructor(
 
     companion object {
         const val ENDPOINT_PRODUCTION = "https://receiver.neuroid.cloud/c"
-
+        val ACTIVE_REGISTERED_TARGETS = mutableSetOf<String>()
         private var singleton: NeuroID? = null
 
         @JvmStatic


### PR DESCRIPTION
Fix for the condition where edit text fields will add duplicate text watchers when app is backgrounded then foregrounded. This will send unwanted additional text input events back the server. This is fixed in the release/debug/reactnative flavors. 

Fix for the condition where a registered text watcher will send an unwanted paste event on every text input after a paste into the edit text field is done. All flavor fix. 

