### PR TITLE
ENG 5952 fix edit text update

### DIFF
--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -234,7 +234,6 @@ class NIDActivityCallbacks : ActivityLifecycleCallbacks {
 
     override fun onActivityDestroyed(activity: Activity) {
 //        NIDLog.d("NID--Activity", "Activity - Destroyed")
-        NeuroID.NID_TEXT_WATCHERS.clear()
         val gyroData = NIDSensorHelper.getGyroscopeInfo()
         val accelData = NIDSensorHelper.getAccelerometerInfo()
         val activityDestroyed = activity::class.java.name

--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -286,11 +286,14 @@ private fun registerListeners(view: View) {
         )
         // add Text Change watcher
         val textWatcher = NIDTextWatcher(idName, simpleClassName)
-        // first we have to clear the text watchers that is currently in the EditText
+        // first we have to clear the text watcher that is currently in the EditText
         for(watcher in textWatchers) {
             view.removeTextChangedListener(watcher)
         }
+        // we add the new one in there
         view.addTextChangedListener(textWatcher)
+        // we add the new one to the list of existing text watchers so we can remove it later when
+        // it is re-registered
         textWatchers.add(textWatcher)
 
         // add original action menu watcher

--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -1,6 +1,7 @@
 package com.neuroid.tracker.events
 
 import android.os.Build
+import android.text.TextWatcher
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.OnHierarchyChangeListener
@@ -268,17 +269,15 @@ fun registerComponent(
         )
 }
 
+// list of text watchers in the entire app
+val textWatchers = mutableListOf<TextWatcher>()
+
 private fun registerListeners(view: View) {
     val idName = view.getIdOrTag()
     val simpleClassName = view.javaClass.simpleName
     val gyroData = NIDSensorHelper.getGyroscopeInfo()
     val accelData = NIDSensorHelper.getAccelerometerInfo()
 
-    // If we have already added the listener here.
-    if (NeuroID.NID_TEXT_WATCHERS.contains(view.getIdOrTag())){
-        return
-    }
-    NeuroID.NID_TEXT_WATCHERS.add(view.getIdOrTag())
     // EditText is a parent class to multiple components
     if (view is EditText) {
         NIDLog.d(
@@ -287,7 +286,12 @@ private fun registerListeners(view: View) {
         )
         // add Text Change watcher
         val textWatcher = NIDTextWatcher(idName, simpleClassName)
+        // first we have to clear the text watchers that is currently in the EditText
+        for(watcher in textWatchers) {
+            view.removeTextChangedListener(watcher)
+        }
         view.addTextChangedListener(textWatcher)
+        textWatchers.add(textWatcher)
 
         // add original action menu watcher
         val actionCallback = view.customSelectionActionModeCallback

--- a/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
@@ -83,8 +83,6 @@ class NeuroID private constructor(
 
         private var singleton: NeuroID? = null
 
-        public var NID_TEXT_WATCHERS = mutableListOf<String>();
-
         @JvmStatic
         fun setNeuroIdInstance(neuroId: NeuroID) {
             if (singleton == null) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
@@ -1,5 +1,6 @@
 package com.neuroid.tracker.utils
 
+import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.text.Editable
@@ -42,11 +43,17 @@ class NIDTextWatcher(
             ?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clipData = clipboard?.primaryClip
         if (clipData != null && clipData.itemCount > 0) {
-            val pastedText = clipData.getItemAt(0).text
+            var pastedText = ""
+            try {
+                pastedText = clipData.getItemAt(0).text.toString()
+            } catch (e: Exception) {
+                e.message?.let {
+                    NIDLog.e("NID-Activity",it)
+                }
+            }
             val pasteCount = pastedText.length
             if (sequence.toString().contains(pastedText) && (pasteCount == count)) {
                 // The change is likely due to a paste operation
-
                 val ts = System.currentTimeMillis()
                 val gyroData = NIDSensorHelper.getGyroscopeInfo()
                 val accelData = NIDSensorHelper.getAccelerometerInfo()

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -270,6 +270,9 @@ fun registerComponent(
         )
 }
 
+// list of text watchers in the entire app
+val textWatchers = mutableListOf<TextWatcher>()
+
 private fun registerListeners(view: View) {
     val idName = view.getIdOrTag()
     val simpleClassName = view.javaClass.simpleName
@@ -284,7 +287,15 @@ private fun registerListeners(view: View) {
         )
         // add Text Change watcher
         val textWatcher = NIDTextWatcher(idName, simpleClassName)
+        // first we have to clear the text watcher that is currently in the EditText
+        for(watcher in textWatchers) {
+            view.removeTextChangedListener(watcher)
+        }
+        // we add the new one in there
         view.addTextChangedListener(textWatcher)
+        // we add the new one to the list of existing text watchers so we can remove it later when
+        // it is re-registered
+        textWatchers.add(textWatcher)
 
         // add original action menu watcher
         val actionCallback = view.customSelectionActionModeCallback

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import android.text.TextWatcher
 import android.widget.*
 import android.widget.RadioGroup
 import androidx.core.view.children

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -276,11 +276,6 @@ private fun registerListeners(view: View) {
     val gyroData = NIDSensorHelper.getGyroscopeInfo()
     val accelData = NIDSensorHelper.getAccelerometerInfo()
 
-    // If we have already added the listener here.
-    if (NeuroID.NID_TEXT_WATCHERS.contains(view.getIdOrTag())){
-        return
-    }
-    NeuroID.NID_TEXT_WATCHERS.add(view.getIdOrTag())
     // EditText is a parent class to multiple components
     if (view is EditText) {
         NIDLog.d(

--- a/NeuroID/src/release/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/release/java/com/neuroid/tracker/NeuroID.kt
@@ -82,7 +82,6 @@ class NeuroID private constructor(
 
         private var singleton: NeuroID? = null
 
-        public var NID_TEXT_WATCHERS = mutableListOf<String>();
         @JvmStatic
         fun setNeuroIdInstance(neuroId: NeuroID) {
             if (singleton == null) {


### PR DESCRIPTION
Remove and add only our text watchers to the edit text fields that are registered.
   
Need to look at event callbacks in NIDActivityCallbacks/NIDFragmentCallbacks later to figure out how to the not double register ui widgets. 