### PR TITLE
update staging workflow and release notes

### DIFF
--- a/.github/workflows/github-actions-push-assamble.yml
+++ b/.github/workflows/github-actions-push-assamble.yml
@@ -51,7 +51,7 @@ jobs:
             git commit -m "updating libraries"
             git push
 
-       - name: Push SDK on Sandbox Project
+      - name: Push SDK on Sandbox Project
          uses: dmnemec/copy_file_to_another_repo_action@main
          env:
            API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/github-actions-push-assamble.yml
+++ b/.github/workflows/github-actions-push-assamble.yml
@@ -10,6 +10,7 @@ env:
   GIT_HASH: ${{github.sha}}
 jobs:
   publish:
+    if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/') != true
     name: Release NeuroID SDK (Staging)
     runs-on: ubuntu-latest
 
@@ -50,18 +51,19 @@ jobs:
             git commit -m "updating libraries"
             git push
 
-      - name: Push SDK on Sandbox Project
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source_file: 'NeuroID/build/outputs/aar/androidLib/'
-          destination_repo: 'Neuro-ID/neuroid-android-sdk-sandbox'
-          destination_folder: 'app/libs/'
-          user_email: 'developer@neuro-id.com'
-          user_name: 'neuroid-developer'
-          destination_branch: 'master'
-          commit_message: ${{ github.event.head_commit.message }}
+      #  TODO Create a development tag that will update only the development Sandbox app
+      # - name: Push SDK on Sandbox Project
+      #   uses: dmnemec/copy_file_to_another_repo_action@main
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #   with:
+      #     source_file: 'NeuroID/build/outputs/aar/androidLib/'
+      #     destination_repo: 'Neuro-ID/neuroid-android-sdk-sandbox'
+      #     destination_folder: 'app/libs/'
+      #     user_email: 'developer@neuro-id.com'
+      #     user_name: 'neuroid-developer'
+      #     destination_branch: 'master'
+      #     commit_message: ${{ github.event.head_commit.message }}
 
       - name: Push SDK on ReactNative Project
         uses: dmnemec/copy_file_to_another_repo_action@main

--- a/.github/workflows/github-actions-push-assamble.yml
+++ b/.github/workflows/github-actions-push-assamble.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish:
     if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/') != true
-    name: Release NeuroID SDK (Staging)
+    name: Release NeuroID SDK
     runs-on: ubuntu-latest
 
     steps:
@@ -51,19 +51,18 @@ jobs:
             git commit -m "updating libraries"
             git push
 
-      #  TODO Create a development tag that will update only the development Sandbox app
-      # - name: Push SDK on Sandbox Project
-      #   uses: dmnemec/copy_file_to_another_repo_action@main
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #   with:
-      #     source_file: 'NeuroID/build/outputs/aar/androidLib/'
-      #     destination_repo: 'Neuro-ID/neuroid-android-sdk-sandbox'
-      #     destination_folder: 'app/libs/'
-      #     user_email: 'developer@neuro-id.com'
-      #     user_name: 'neuroid-developer'
-      #     destination_branch: 'master'
-      #     commit_message: ${{ github.event.head_commit.message }}
+       - name: Push SDK on Sandbox Project
+         uses: dmnemec/copy_file_to_another_repo_action@main
+         env:
+           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+         with:
+           source_file: 'NeuroID/build/outputs/aar/androidLib/'
+           destination_repo: 'Neuro-ID/neuroid-android-sdk-sandbox'
+           destination_folder: 'app/libs/'
+           user_email: 'developer@neuro-id.com'
+           user_name: 'neuroid-developer'
+           destination_branch: 'master'
+           commit_message: ${{ github.event.head_commit.message }}
 
       - name: Push SDK on ReactNative Project
         uses: dmnemec/copy_file_to_another_repo_action@main

--- a/.github/workflows/github-actions-push-assamble.yml
+++ b/.github/workflows/github-actions-push-assamble.yml
@@ -52,17 +52,17 @@ jobs:
             git push
 
       - name: Push SDK on Sandbox Project
-         uses: dmnemec/copy_file_to_another_repo_action@main
-         env:
-           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-         with:
-           source_file: 'NeuroID/build/outputs/aar/androidLib/'
-           destination_repo: 'Neuro-ID/neuroid-android-sdk-sandbox'
-           destination_folder: 'app/libs/'
-           user_email: 'developer@neuro-id.com'
-           user_name: 'neuroid-developer'
-           destination_branch: 'master'
-           commit_message: ${{ github.event.head_commit.message }}
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: 'NeuroID/build/outputs/aar/androidLib/'
+          destination_repo: 'Neuro-ID/neuroid-android-sdk-sandbox'
+          destination_folder: 'app/libs/'
+          user_email: 'developer@neuro-id.com'
+          user_name: 'neuroid-developer'
+          destination_branch: 'master'
+          commit_message: ${{ github.event.head_commit.message }}
 
       - name: Push SDK on ReactNative Project
         uses: dmnemec/copy_file_to_another_repo_action@main

--- a/.github/workflows/github-actions-tag-assamble.yml
+++ b/.github/workflows/github-actions-tag-assamble.yml
@@ -45,17 +45,12 @@ jobs:
             git config --global user.name "neuroid-developer"
             git tag -a v${{env.GITHUB_SDK_VERSION}} -m "Neuro-ID Android SDK Version: ${{env.GITHUB_SDK_VERSION}}"
             git push
+            echo "TAG_NAME=v${{env.GITHUB_SDK_VERSION}}" >> $GITHUB_ENV
 
       - name: Create Release ✅
-        id: create_release
-        uses: actions/create-release@v1
+        run: gh release create ${{ env.TAG_NAME }} --generate-notes --title "${{ env.TAG_NAME }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{env.GITHUB_SDK_VERSION}}
-          release_name: v${{env.GITHUB_SDK_VERSION}}
-          draft: false
-          prerelease: false
 
       - name: Upload Native AAR 🗳
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Updating staging workflow to trigger on merge to main (except on release). This will update the sandbox app every time. Added automated release notes to workflow.