### PR TITLE
ENG-6208 - Observe changes in activity children

### DIFF
--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -14,7 +14,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 
-
 class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
     private var auxOrientation = -1
     private var activitiesStarted = 1
@@ -124,16 +123,6 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
                     attrs = attrJSON
                 )
             )
-
-
-        val currentActivityName = activity::class.java.name
-        registerTargetFromScreen(
-            activity,
-            registerTarget = true,
-            registerListeners = true,
-            activityOrFragment = "activity",
-            parent = currentActivityName
-        )
     }
 
     override fun onActivityPaused(activity: Activity) {

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -124,6 +124,16 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
                     attrs = attrJSON
                 )
             )
+
+
+        val currentActivityName = activity::class.java.name
+        registerTargetFromScreen(
+            activity,
+            registerTarget = true,
+            registerListeners = true,
+            activityOrFragment = "activity",
+            parent = currentActivityName
+        )
     }
 
     override fun onActivityPaused(activity: Activity) {

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -61,7 +61,7 @@ fun identifyAllViews(
                         child?.let { view ->
                             // This is double registering targets and registering listeners before the correct
                             //  lifecycle event which is causing a replay of text input events to occur
-//                            identifyView(view, guid, registerTarget, registerListeners)
+                            identifyView(view, guid, registerTarget, registerListeners)
                         }
                     }
 

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/events/NIDIdentifyAllViews.kt
@@ -61,7 +61,7 @@ fun identifyAllViews(
                         child?.let { view ->
                             // This is double registering targets and registering listeners before the correct
                             //  lifecycle event which is causing a replay of text input events to occur
-                            identifyView(view, guid, registerTarget, registerListeners)
+//                            identifyView(view, guid, registerTarget, registerListeners)
                         }
                     }
 
@@ -287,7 +287,11 @@ private fun registerListeners(view: View) {
             "EditText Listener $simpleClassName - ${view::class} - ${view.getIdOrTag()}"
         )
         // add Text Change watcher
-        val textWatcher = NIDTextWatcher(idName, simpleClassName)
+        val textWatcher = NIDTextWatcher(
+            idName,
+            simpleClassName,
+            "${view.text.toString().getSHA256withSalt()?.take(8)}"
+        )
         // first we have to clear the text watcher that is currently in the EditText
         for(watcher in textWatchers) {
             view.removeTextChangedListener(watcher)


### PR DESCRIPTION
The fix for RN is to uncomment out the line we removed in the Android Native SDK because it was causing double event registration, however because of how RN creates/destroys activities we have to put this back in to capture all the changes when a user goes to a new page. If you have more questions lmk