### PR TITLE
ENG 6219 add back window events

### DIFF
--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -95,6 +95,7 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
             activityOrFragment = "activity",
             parent = activity::class.java.name
         )
+        registerWindowListeners(activity)
     }
 
     override fun onActivityStarted(activity: Activity) {

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -95,6 +95,7 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
             activityOrFragment = "activity",
             parent = activity::class.java.name
         )
+        // register listeners for focus, blur and touch events
         registerWindowListeners(activity)
     }
 


### PR DESCRIPTION
Re-registering the window listeners in the forceStart() on whatever widgets are currently available on the screen at the time will send back the touch, blur and focus events. This has to be done on startup of every screen in the ReactNative end. 