### PR TITLE
ENG-6273 remove API 29 calls 

### DIFF
--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -28,7 +28,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdk 16
+        minSdk 21
         targetSdk 31
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -8,12 +8,10 @@ import com.neuroid.tracker.events.*
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.service.NIDServiceTracker
 import com.neuroid.tracker.storage.getDataStoreInstance
-import com.neuroid.tracker.utils.hasFragments
 import com.neuroid.tracker.utils.NIDLog
 import com.neuroid.tracker.utils.NIDLogWrapper
 import org.json.JSONArray
 import org.json.JSONObject
-
 
 class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
     private var auxOrientation = -1
@@ -22,12 +20,10 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
     private var wasChanged = false
 
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
-
+        // no operation
     }
 
-    override fun onActivityPostCreated(activity: Activity, savedInstanceState: Bundle?) {
-        NIDLog.d("Neuro ID", "NIDDebug onActivityCreated");
-
+    override fun onActivityStarted(activity: Activity) {
         val currentActivityName = activity::class.java.name
         val orientation = activity.resources.configuration.orientation
         val existActivity = listActivities.contains(currentActivityName)
@@ -88,7 +84,7 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
     }
 
 
-    public fun forceStart(activity: Activity) {
+    fun forceStart(activity: Activity) {
         registerTargetFromScreen(
             activity,
             registerTarget = true,
@@ -102,13 +98,7 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
         registerWindowListeners(activity)
     }
 
-    override fun onActivityStarted(activity: Activity) {
-
-    }
-
     override fun onActivityResumed(activity: Activity) {
-        //No operation
-
         val gyroData = NIDSensorHelper.getGyroscopeInfo()
         val accelData = NIDSensorHelper.getAccelerometerInfo()
 
@@ -131,9 +121,6 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
     }
 
     override fun onActivityPaused(activity: Activity) {
-        //No operation
-
-
         val gyroData = NIDSensorHelper.getGyroscopeInfo()
         val accelData = NIDSensorHelper.getAccelerometerInfo()
 
@@ -157,20 +144,6 @@ class NIDActivityCallbacks() : ActivityLifecycleCallbacks {
 
     override fun onActivityStopped(activity: Activity) {
         activitiesStarted--
-//        if (activitiesStarted == 0) {
-//            val gyroData = NIDSensorHelper.getGyroscopeInfo()
-//            val accelData = NIDSensorHelper.getAccelerometerInfo()
-//
-//            getDataStoreInstance()
-//                .saveEvent(
-//                    NIDEventModel(
-//                        type = WINDOW_BLUR,
-//                        ts = System.currentTimeMillis(),
-//                        gyro = gyroData,
-//                        accel = accelData
-//                    )
-//                )
-//        }
     }
 
     override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {


### PR DESCRIPTION
- move the implementation from onActivityPostCreated to onActivityStarted in android lib and react native activity callbacks 
- change min target to 21 in NeuroID module
- cleanup

To test this
- Create a simulator with an API 21 image. To do this go to Android Studio, tools-> device manager and click on the "Create Device" button. In the pop up choose a hardware profile (Pixel 2 is fine) and click next. Click on the Arm Images tab, scroll the table to an API level 21 system image and click the download icon in the first column (Release Name) to download the image. If the download icon is not there, you already have the image downloaded. Highlight the row, click next and click finish. You don't need to set anything else after you have chosen a system image. You simulator can now be chosen from the device tab.  

<img width="1041" alt="image" src="https://github.com/Neuro-ID/neuroid-android-sdk/assets/139158682/065b4129-17ec-45f8-8c33-70d508ed8a69">


- build the lib and copy to a sandbox app of your choice (layout, fragment, whatever)
- run it with your new simulator (choose the proper device in the tab show below) and ensure the events are firing properly. 
<img width="468" alt="image" src="https://github.com/Neuro-ID/neuroid-android-sdk/assets/139158682/bfd9c5ff-a9e8-4857-8c4c-a4f89442a386">

Let me know if you have any questions. Thank you. 