### PR TITLE
ENG-6395 need to check if members are empty before updating with default values

### DIFF
--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -34,11 +34,15 @@ class NIDActivityCallbacks: ActivityCallbacks() {
         val existActivity = listActivities.contains(currentActivityName)
 
         NIDServiceTracker.screenActivityName = currentActivityName
-        if (NIDServiceTracker.firstScreenName.isBlank()) {
+        if (NIDServiceTracker.firstScreenName.isNullOrEmpty()) {
             NIDServiceTracker.firstScreenName = currentActivityName
         }
-        NIDServiceTracker.screenFragName = ""
-        NIDServiceTracker.screenName = "AppInit"
+        if (NIDServiceTracker.screenFragName.isNullOrEmpty()) {
+            NIDServiceTracker.screenFragName = ""
+        }
+        if (NIDServiceTracker.screenName.isNullOrEmpty()) {
+            NIDServiceTracker.screenName = "AppInit"
+        }
         wasChanged = auxOrientation != orientation
 
         val gyroData = NIDSensorHelper.getGyroscopeInfo()

--- a/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDFragmentCallbacks.kt
+++ b/NeuroID/src/androidLib/java/com/neuroid/tracker/callbacks/NIDFragmentCallbacks.kt
@@ -18,8 +18,12 @@ class NIDFragmentCallbacks(
     override fun onFragmentAttached(fm: FragmentManager, f: Fragment, context: Context) {
         NIDLog.d("NID-Fragment", "Fragment - Attached ${f::class.java.simpleName}")
         if (blackListFragments.any { it == f::class.java.simpleName }.not()) {
-            NIDServiceTracker.screenName = "AppInit"
-            NIDServiceTracker.screenFragName = f::class.java.simpleName
+            if (NIDServiceTracker.screenName.isNullOrEmpty()) {
+                NIDServiceTracker.screenName = "AppInit"
+            }
+            if (NIDServiceTracker.screenFragName.isNullOrEmpty()) {
+                NIDServiceTracker.screenFragName = f::class.java.simpleName
+            }
             val gyroData = NIDSensorHelper.getGyroscopeInfo()
             val accelData = NIDSensorHelper.getAccelerometerInfo()
 

--- a/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
+++ b/NeuroID/src/reactNativeLib/java/com/neuroid/tracker/callbacks/NIDActivityCallbacks.kt
@@ -19,9 +19,15 @@ class NIDActivityCallbacks() : ActivityCallbacks() {
         val orientation = activity.resources.configuration.orientation
         val existActivity = listActivities.contains(currentActivityName)
 
-        NIDServiceTracker.screenActivityName = currentActivityName
-        NIDServiceTracker.screenFragName = ""
-        NIDServiceTracker.screenName = "AppInit"
+        if (NIDServiceTracker.screenActivityName.isNullOrEmpty()) {
+            NIDServiceTracker.screenActivityName = currentActivityName
+        }
+        if (NIDServiceTracker.screenFragName.isNullOrEmpty()) {
+            NIDServiceTracker.screenFragName = ""
+        }
+        if (NIDServiceTracker.screenName.isNullOrEmpty()) {
+            NIDServiceTracker.screenName = "AppInit"
+        }
 
         val changedOrientation = auxOrientation != orientation
         wasChanged = changedOrientation


### PR DESCRIPTION
Some of the attributes were overwritten after the activity was created. Added some checks to ensure we don't overwrite non empty values. 

Call in activity onCreate() method. 

NeuroID.getInstance()?.setScreenName(this.localClassName)
 
logcat before:
{"n":"screenHierarchy","v":"ConstraintLayout/AppInit"}

logcat after: 
{"n":"screenHierarchy","v":"ConstraintLayout/com.neuroid.example.PersonalInformation"}

