### PR TITLE
ENG-6460-caching Request id for 24 hrs

### DIFF
--- a/NeuroID/src/advancedDeviceAndroidLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/advancedDeviceAndroidLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -34,8 +34,8 @@ fun NeuroID.start(advancedDeviceSignals: Boolean) {
                         )
                     }
                     //  Retrieving the Request ID from FPJS
-                    var fpjsHelper = FPJSHelper()
-                    fpjsHelper.createRequestIdEvent(fpjsClient, fpjsRetryCount, FPJS_RETRY_MAX)
+                    var fpjsHelper = applicationContext?.let { FPJSHelper(it) }
+                    fpjsHelper?.createRequestIdEvent(fpjsClient, fpjsRetryCount, FPJS_RETRY_MAX)
                 }
 
                 override fun onFailure(message: String, responseCode: Int) {

--- a/NeuroID/src/advancedDeviceAndroidLib/java/com/neuroid/tracker/utils/FPJSHelper.kt
+++ b/NeuroID/src/advancedDeviceAndroidLib/java/com/neuroid/tracker/utils/FPJSHelper.kt
@@ -1,55 +1,86 @@
 package com.neuroid.tracker.utils
+
+import android.content.Context
 import com.fingerprintjs.android.fpjs_pro.FingerprintJS
-import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.events.ADVANCED_DEVICE_REQUEST
 import com.neuroid.tracker.events.LOG
 import com.neuroid.tracker.models.NIDEventModel
+import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
 import com.neuroid.tracker.storage.getDataStoreInstance
 
-class FPJSHelper {
+class FPJSHelper(private val context: Context) {
     fun createRequestIdEvent(fpjsClient: FingerprintJS?, fpjsRetryCount: Int, maxRetryCount: Int) {
         var retryCount = fpjsRetryCount
-        fpjsClient?.getVisitorId(listener = { result ->
-            val gyroData = NIDSensorHelper.getGyroscopeInfo()
-            val accelData = NIDSensorHelper.getAccelerometerInfo()
+
+        // Check if request id is in cache and has expired
+        val sharedDefaults = NIDSharedPrefsDefaults(context)
+        if (sharedDefaults.hasRequestIdExpired()) {
             NIDLog.d(
                 "NIDDebugEvent",
-                "Request ID for Advanced Device Signals: ${result.requestId}"
+                "Request ID not found in cache"
+            )
+            // Request Id from server
+            fpjsClient?.getVisitorId(listener = { result ->
+                NIDLog.d(
+                    "NIDDebugEvent",
+                    "Generating Request ID for Advanced Device Signals: ${result.requestId}"
+                )
+                getDataStoreInstance().saveEvent(
+                    NIDEventModel(
+                        type = ADVANCED_DEVICE_REQUEST,
+                        rid = result.requestId,
+                        ts = System.currentTimeMillis(),
+                        c = false
+                    )
+                )
+            // Cache request Id for 24 hours
+                NIDLog.d(
+                    "NIDDebugEvent",
+                    "Caching Request ID: ${result.requestId}"
+                )
+                sharedDefaults.cacheRequestId(result.requestId)
+                sharedDefaults.cacheRequestIdExpirationTimestamp()
+            },
+                errorListener = { error ->
+                    retryCount += 1
+                    NIDLog.d(
+                        "NIDDebugEvent",
+                        "Error retrieving Advanced Device Signal Request ID:${error.description}: $fpjsRetryCount"
+                    )
+                    Thread.sleep(5000)
+                    if (retryCount < maxRetryCount) {
+                        createRequestIdEvent(fpjsClient, retryCount, maxRetryCount)
+                    } else {
+                        getDataStoreInstance().saveEvent(
+                            NIDEventModel(
+                                type = LOG,
+                                ts = System.currentTimeMillis(),
+                                level="error",
+                                m="Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
+                            )
+                        )
+                        NIDLog.e(
+                            "NeuroId",
+                            "Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
+                        )
+                    }
+
+                })
+        } else {
+            //  Retrieve request id from cache
+            val requestId = sharedDefaults.getCachedRequestId()
+            NIDLog.d(
+                "NIDDebugEvent",
+                "Retrieving Request ID for Advanced Device Signals from cache: ${requestId}"
             )
             getDataStoreInstance().saveEvent(
                 NIDEventModel(
                     type = ADVANCED_DEVICE_REQUEST,
-                    rid = result.requestId,
-                    gyro = gyroData,
-                    accel = accelData,
+                    rid = requestId,
                     ts = System.currentTimeMillis(),
+                    c = true
                 )
             )
-        },
-            errorListener = { error ->
-                retryCount += 1
-                NIDLog.d(
-                    "NIDDebugEvent",
-                    "Error retrieving Advanced Device Signal Request ID:${error.description}: $fpjsRetryCount"
-                )
-                Thread.sleep(5000)
-                if (retryCount < maxRetryCount) {
-                    createRequestIdEvent(fpjsClient, retryCount, maxRetryCount)
-                } else {
-                    getDataStoreInstance().saveEvent(
-                        NIDEventModel(
-                            type = LOG,
-                            ts = System.currentTimeMillis(),
-                            level="error",
-                            m="Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
-                        )
-                    )
-                    NIDLog.e(
-                        "NeuroId",
-                        "Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
-                    )
-                }
-
-            })
+        }
     }
 }

--- a/NeuroID/src/advancedDeviceReactNativeLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/advancedDeviceReactNativeLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -31,8 +31,8 @@ fun NeuroID.start(advancedDeviceSignals: Boolean) {
                         )
                     }
                     //  Retrieving the Request ID from FPJS
-                    var fpjsHelper = FPJSHelper()
-                    fpjsHelper.createRequestIdEvent(fpjsClient, fpjsRetryCount, FPJS_RETRY_MAX)
+                    var fpjsHelper = applicationContext?.let { FPJSHelper(it) }
+                    fpjsHelper?.createRequestIdEvent(fpjsClient, fpjsRetryCount, FPJS_RETRY_MAX)
                 }
 
                 override fun onFailure(message: String, responseCode: Int) {

--- a/NeuroID/src/advancedDeviceReactNativeLib/java/com/neuroid/tracker/utils/FPJSHelper.kt
+++ b/NeuroID/src/advancedDeviceReactNativeLib/java/com/neuroid/tracker/utils/FPJSHelper.kt
@@ -1,9 +1,11 @@
 package com.neuroid.tracker.utils
+
+import android.content.Context
 import com.fingerprintjs.android.fpjs_pro.FingerprintJS
-import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.events.ADVANCED_DEVICE_REQUEST
 import com.neuroid.tracker.events.LOG
 import com.neuroid.tracker.models.NIDEventModel
+import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
 import com.neuroid.tracker.storage.getDataStoreInstance
 
 class FPJSHelper(private val context: Context) {

--- a/NeuroID/src/advancedDeviceReactNativeLib/java/com/neuroid/tracker/utils/FPJSHelper.kt
+++ b/NeuroID/src/advancedDeviceReactNativeLib/java/com/neuroid/tracker/utils/FPJSHelper.kt
@@ -6,50 +6,79 @@ import com.neuroid.tracker.events.LOG
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.storage.getDataStoreInstance
 
-class FPJSHelper {
+class FPJSHelper(private val context: Context) {
     fun createRequestIdEvent(fpjsClient: FingerprintJS?, fpjsRetryCount: Int, maxRetryCount: Int) {
         var retryCount = fpjsRetryCount
-        fpjsClient?.getVisitorId(listener = { result ->
-            val gyroData = NIDSensorHelper.getGyroscopeInfo()
-            val accelData = NIDSensorHelper.getAccelerometerInfo()
+
+        // Check if request id is in cache and has expired
+        val sharedDefaults = NIDSharedPrefsDefaults(context)
+        if (sharedDefaults.hasRequestIdExpired()) {
             NIDLog.d(
                 "NIDDebugEvent",
-                "Request ID for Advanced Device Signals: ${result.requestId}"
+                "Request ID not found in cache"
+            )
+            // Request Id from server
+            fpjsClient?.getVisitorId(listener = { result ->
+                NIDLog.d(
+                    "NIDDebugEvent",
+                    "Generating Request ID for Advanced Device Signals: ${result.requestId}"
+                )
+                getDataStoreInstance().saveEvent(
+                    NIDEventModel(
+                        type = ADVANCED_DEVICE_REQUEST,
+                        rid = result.requestId,
+                        ts = System.currentTimeMillis(),
+                        c = false
+                    )
+                )
+                // Cache request Id for 24 hours
+                NIDLog.d(
+                    "NIDDebugEvent",
+                    "Caching Request ID: ${result.requestId}"
+                )
+                sharedDefaults.cacheRequestId(result.requestId)
+                sharedDefaults.cacheRequestIdExpirationTimestamp()
+            },
+                errorListener = { error ->
+                    retryCount += 1
+                    NIDLog.d(
+                        "NIDDebugEvent",
+                        "Error retrieving Advanced Device Signal Request ID:${error.description}: $fpjsRetryCount"
+                    )
+                    Thread.sleep(5000)
+                    if (retryCount < maxRetryCount) {
+                        createRequestIdEvent(fpjsClient, retryCount, maxRetryCount)
+                    } else {
+                        getDataStoreInstance().saveEvent(
+                            NIDEventModel(
+                                type = LOG,
+                                ts = System.currentTimeMillis(),
+                                level="error",
+                                m="Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
+                            )
+                        )
+                        NIDLog.e(
+                            "NeuroId",
+                            "Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
+                        )
+                    }
+
+                })
+        } else {
+            //  Retrieve request id from cache
+            val requestId = sharedDefaults.getCachedRequestId()
+            NIDLog.d(
+                "NIDDebugEvent",
+                "Retrieving Request ID for Advanced Device Signals from cache: ${requestId}"
             )
             getDataStoreInstance().saveEvent(
                 NIDEventModel(
                     type = ADVANCED_DEVICE_REQUEST,
-                    rid = result.requestId,
-                    gyro = gyroData,
-                    accel = accelData,
+                    rid = requestId,
                     ts = System.currentTimeMillis(),
+                    c = true
                 )
             )
-        },
-            errorListener = { error ->
-                retryCount += 1
-                NIDLog.d(
-                    "NIDDebugEvent",
-                    "Error retrieving Advanced Device Signal Request ID:${error.description}: $fpjsRetryCount"
-                )
-                Thread.sleep(5000)
-                if (retryCount < maxRetryCount) {
-                    createRequestIdEvent(fpjsClient, retryCount, maxRetryCount)
-                } else {
-                    getDataStoreInstance().saveEvent(
-                        NIDEventModel(
-                            type = LOG,
-                            ts = System.currentTimeMillis(),
-                            level="error",
-                            m="Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
-                        )
-                    )
-                    NIDLog.e(
-                        "NeuroId",
-                        "Reached maximum number of retries ($maxRetryCount) to get Advanced Device Signal Request ID:${error.description}"
-                    )
-                }
-
-            })
+        }
     }
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -57,6 +57,7 @@ data class NIDEventModel(
     val rid: String? = null,
     val m: String? = null,
     val level: String? = null,
+    val c: Boolean? = null
 ) : Comparable<NIDEventModel> {
     fun getOwnJson(): String {
         val jsonObject = JSONObject()
@@ -122,6 +123,7 @@ data class NIDEventModel(
             url?.let { jsonObject.put("url", it) }
             ns?.let { jsonObject.put("ns", it) }
             rid?.let { jsonObject.put("rid", it) }
+            c?.let { jsonObject.put("c", it) }
             jsl?.let {
                 val values = JSONArray()
                 jsonObject.put("jsl", values)

--- a/NeuroID/src/main/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
@@ -109,7 +109,7 @@ private object NIDDataStoreManagerImp : NIDDataStoreManager {
                     WINDOW_BLUR -> contextString = "meta=${event.metadata}"
                     WINDOW_FOCUS -> contextString = "meta=${event.metadata}"
                     CONTEXT_MENU -> contextString = "meta=${event.metadata}"
-                    ADVANCED_DEVICE_REQUEST -> contextString = "rid=${event.rid}"
+                    ADVANCED_DEVICE_REQUEST -> contextString = "rid=${event.rid}, c=${event.c}"
                     LOG -> contextString = "m=${event.m}, ts=${event.ts}, level=${event.level}"
                     else -> {}
                 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/storage/NIDSharedPrefsDefaults.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/storage/NIDSharedPrefsDefaults.kt
@@ -130,6 +130,45 @@ class NIDSharedPrefsDefaults(
         return sharedPref?.getString(key, "") ?: default
     }
 
+    private fun putLong(key: String, value: Long) {
+        CoroutineScope(Dispatchers.IO).launch {
+            sharedPref?.let {
+                with(it.edit()) {
+                    putLong(key, value)
+                    apply()
+                }
+            }
+        }
+    }
+
+    private fun getLong(key: String, default: Long = 0): Long {
+        return sharedPref?.getLong(key, 0) ?: default
+    }
+
+    fun cacheRequestId(fpjsRequestId: String) {
+        putString(NID_RID, fpjsRequestId)
+    }
+
+    // Save 24 hr expiration timestamp for cached Request Id
+    fun cacheRequestIdExpirationTimestamp() {
+        val currentTimeMillis = System.currentTimeMillis()
+        val twentyFourHoursInMillis = 24 * 60 * 60 * 1000
+        putLong(NID_RID_TS_EXP, twentyFourHoursInMillis + currentTimeMillis)
+    }
+
+    fun getCachedRequestId(): String {
+        return getString(NID_RID)
+    }
+
+    fun hasRequestIdExpired(): Boolean {
+        val nidRidExpirationTimestamp = getLong(NID_RID_TS_EXP)
+        val currentTimestamp = System.currentTimeMillis()
+        if (currentTimestamp > nidRidExpirationTimestamp) {
+            return true
+        }
+        return false
+    }
+
     companion object {
         private const val NID_SHARED_PREF_FILE = "NID_SHARED_PREF_FILE"
         private const val NID_UID = "NID_UID_KEY"
@@ -139,6 +178,9 @@ class NIDSharedPrefsDefaults(
         private const val NID_DID = "NID_DID_KEY"
         private const val NID_IID = "NID_IID_KEY"
         private const val NID_DEVICE_SALT = "NID_DEVICE_SALT"
+        private const val NID_RID = "NID_RID_KEY"
+        private const val NID_RID_TS_EXP = "NID_RID_TS_EXP"
+
 
         fun getHexRandomID(): String = List(12) {
             (('a'..'f') + ('0'..'9')).random()


### PR DESCRIPTION
If an FPJS key exists for the application, the request ID will be fetched from cache if its not expired. Else it will refresh the id.