### PR TITLE
Eng 6482 unit test request id cache

### DIFF
--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -42,6 +42,10 @@ jobs:
         - name: Unit Test NeuroId
           run: ./gradlew :NeuroID:testAndroidLibDebugUnitTest
 
+        # Execute unit test neuroid lib
+        - name: Unit Test NeuroId
+          run: ./gradlew :NeuroID:testAdvancedDeviceAndroidLibDebugUnitTest
+
         # Execute unit tests
         - name: Unit Test
           uses: ReactiveCircus/android-emulator-runner@v2.24.0

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -43,7 +43,7 @@ jobs:
           run: ./gradlew :NeuroID:testAndroidLibDebugUnitTest
 
         # Execute unit test neuroid lib
-        - name: Unit Test NeuroId
+        - name: Unit Test NeuroId (advanced)
           run: ./gradlew :NeuroID:testAdvancedDeviceAndroidLibDebugUnitTest
 
         # Execute unit tests

--- a/NeuroID/src/advancedDeviceAndroidLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/advancedDeviceAndroidLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -8,12 +8,14 @@ import com.neuroid.tracker.utils.GsonAdvMapper
 import com.neuroid.tracker.utils.HttpConnectionProvider
 import com.neuroid.tracker.service.NIDAdvKeyService
 import com.neuroid.tracker.service.OnKeyCallback
+import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
 import com.neuroid.tracker.storage.getDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import com.neuroid.tracker.utils.FPJSHelper
+import com.neuroid.tracker.utils.NIDLogWrapper
 
 fun NeuroID.start(advancedDeviceSignals: Boolean) {
     start()
@@ -34,8 +36,10 @@ fun NeuroID.start(advancedDeviceSignals: Boolean) {
                         )
                     }
                     //  Retrieving the Request ID from FPJS
-                    var fpjsHelper = applicationContext?.let { FPJSHelper(it) }
-                    fpjsHelper?.createRequestIdEvent(fpjsClient, fpjsRetryCount, FPJS_RETRY_MAX)
+                    applicationContext?.let {
+                        FPJSHelper().createRequestIdEvent(fpjsClient, fpjsRetryCount, FPJS_RETRY_MAX,
+                            NIDSharedPrefsDefaults(it), NIDLogWrapper(), getDataStoreInstance())
+                    }
                 }
 
                 override fun onFailure(message: String, responseCode: Int) {

--- a/NeuroID/src/testAdvancedDeviceAndroidLib/java/com/neuroid/tracker/FPJSHelperTest.kt
+++ b/NeuroID/src/testAdvancedDeviceAndroidLib/java/com/neuroid/tracker/FPJSHelperTest.kt
@@ -1,0 +1,154 @@
+package com.neuroid.tracker
+
+import com.fingerprintjs.android.fpjs_pro.Error
+import com.fingerprintjs.android.fpjs_pro.FingerprintJS
+import com.fingerprintjs.android.fpjs_pro.FingerprintJSProResponse
+import com.neuroid.tracker.storage.NIDDataStoreManager
+import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
+import com.neuroid.tracker.utils.FPJSHelper
+import com.neuroid.tracker.utils.NIDLogWrapper
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.Test
+
+class FPJSHelperTest {
+    @Test
+    fun fpjs_helper_test_has_id_not_expired() {
+        val sharedPrefs = mockk<NIDSharedPrefsDefaults>()
+        every { sharedPrefs.hasRequestIdExpired() } returns false
+        every { sharedPrefs.getCachedRequestId() } returns "572893hjfelsk"
+        val logger = mockk<NIDLogWrapper>()
+        every { logger.d(any(), any()) } just runs
+        val dataStore =mockk<NIDDataStoreManager>()
+        every { dataStore.saveEvent(any()) } just runs
+        val fpjsClient = mockk<FingerprintJS>()
+        val fpjsHelper = FPJSHelper()
+        fpjsHelper.createRequestIdEvent(fpjsClient, 0, 3, sharedPrefs, logger, dataStore)
+        verify { sharedPrefs.getCachedRequestId() }
+        verify { logger.d("NIDDebugEvent", "Retrieving Request ID for Advanced Device Signals from cache: 572893hjfelsk") }
+        verify { dataStore.saveEvent(any())}
+    }
+
+    @Test
+    fun fpjs_helper_test_success_expired_id_or_no_id_stored() {
+        val sharedPrefs = mockk<NIDSharedPrefsDefaults>()
+        every {sharedPrefs.hasRequestIdExpired()} returns true
+        every {sharedPrefs.cacheRequestId(any())} just runs
+        every {sharedPrefs.cacheRequestIdExpirationTimestamp()} just runs
+        val logger = mockk<NIDLogWrapper>()
+        every {logger.d(any(), any())} just runs
+        val dataStore =mockk<NIDDataStoreManager>()
+        every {dataStore.saveEvent(any())} just runs
+        val fpjsHelper = FPJSHelper()
+        fpjsHelper.createRequestIdEvent(fpjsClientFireAPIKeyOK, 0, 3, sharedPrefs, logger, dataStore)
+        verify { logger.d("NIDDebugEvent", "Request ID not found in cache")}
+        verify { logger.d("NIDDebugEvent", "Generating Request ID for Advanced Device Signals: 543sdgsdg") }
+        verify { sharedPrefs.cacheRequestId("543sdgsdg") }
+        verify { sharedPrefs.cacheRequestIdExpirationTimestamp() }
+        verify { dataStore.saveEvent(any())}
+    }
+
+    @Test
+    fun fpjs_helper_test_success_no_id_stored_wrong_api_key() {
+        val sharedPrefs = mockk<NIDSharedPrefsDefaults>()
+        every {sharedPrefs.hasRequestIdExpired()} returns true
+        val logger = mockk<NIDLogWrapper>()
+        every {logger.e(any(), any())} just runs
+        every {logger.d(any(), any())} just runs
+        val dataStore =mockk<NIDDataStoreManager>()
+        every {dataStore.saveEvent(any())} just runs
+        val fpjsHelper = FPJSHelper()
+        fpjsHelper.createRequestIdEvent(fpjsClientFireWrongAPIKey, 0, 3, sharedPrefs, logger, dataStore)
+        verify { logger.d("NIDDebugEvent", "Error retrieving Advanced Device Signal Request ID:no request id available: 0") }
+        verify { logger.d("NIDDebugEvent", "Error retrieving Advanced Device Signal Request ID:no request id available: 1") }
+        verify { logger.d("NIDDebugEvent", "Error retrieving Advanced Device Signal Request ID:no request id available: 2") }
+        verify (exactly = 3){ logger.d("NIDDebugEvent", "Request ID not found in cache")}
+        verify { logger.e("NeuroId", "Reached maximum number of retries (3) to get Advanced Device Signal Request ID:no request id available")}
+        verify { dataStore.saveEvent(any())}
+    }
+
+    private val fpjsClientFireWrongAPIKey = object: FingerprintJS {
+        override fun getVisitorId(listener: (FingerprintJSProResponse) -> Unit) {
+            println("no op")
+        }
+
+        override fun getVisitorId(
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            val response = mockk<Error>()
+            every{response.description} returns "no request id available"
+            every{response.requestId} returns "none"
+            errorListener(response)
+        }
+
+        override fun getVisitorId(
+            linkedId:String,
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            println("no op")
+        }
+
+        override fun getVisitorId(
+            tags: Map<String, Any>,
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            println("no op")
+        }
+
+        override fun getVisitorId(
+            tags: Map<String, Any>,
+            linkedId: String,
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            println("no op")
+        }
+    }
+
+    private val fpjsClientFireAPIKeyOK = object: FingerprintJS {
+        override fun getVisitorId(listener: (FingerprintJSProResponse) -> Unit) {
+            println("no op")
+        }
+
+        override fun getVisitorId(
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            val response = mockk<FingerprintJSProResponse>()
+            every {response.requestId} returns "543sdgsdg"
+            listener(response)
+        }
+
+        override fun getVisitorId(
+            linkedId:String,
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            println("no op")
+        }
+
+        override fun getVisitorId(
+            tags: Map<String, Any>,
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            println("no op")
+        }
+
+        override fun getVisitorId(
+            tags: Map<String, Any>,
+            linkedId: String,
+            listener: (FingerprintJSProResponse) -> Unit,
+            errorListener: (com.fingerprintjs.android.fpjs_pro.Error) -> Unit
+        ) {
+            println("no op")
+        }
+    }
+
+}


### PR DESCRIPTION
Small refactor to pass in required classes (prefs, logger and data store) into the FPJSHelper so these could be mocked in the tests. 

The tests required creating a mock FPJS client to call the success listener and the failure listener to run the success and failure modes in the FPJS.createRequestIdEvent().