### PR TITLE
ENG-6643 fix to not send copy/paste event 

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
@@ -58,26 +58,28 @@ class NIDTextWatcher(
                     val accelData = NIDSensorHelper.getAccelerometerInfo()
 
                     val metadataObj = JSONObject()
-                    metadataObj.put("clipboardText", "S~C~~${pastedText.length}")
+                    if (pastedText.isNotEmpty()) {
+                        metadataObj.put("clipboardText", "S~C~~${pastedText.length}")
 
-                    val attrJSON = JSONArray().put(metadataObj)
-                    getDataStoreInstance()
-                        .saveEvent(
-                            NIDEventModel(
-                                type = PASTE,
-                                ts = ts,
-                                tg = hashMapOf(
-                                    "attr" to getAttrJson(sequence.toString()),
-                                    "et" to "text"
-                                ),
-                                tgs = idName,
-                                v = "S~C~~${sequence?.length}",
-                                hv = sequence?.toString()?.getSHA256withSalt()?.take(8),
-                                gyro = gyroData,
-                                accel = accelData,
-                                attrs = attrJSON
+                        val attrJSON = JSONArray().put(metadataObj)
+                        getDataStoreInstance()
+                            .saveEvent(
+                                NIDEventModel(
+                                    type = PASTE,
+                                    ts = ts,
+                                    tg = hashMapOf(
+                                        "attr" to getAttrJson(sequence.toString()),
+                                        "et" to "text"
+                                    ),
+                                    tgs = idName,
+                                    v = "S~C~~${sequence?.length}",
+                                    hv = sequence?.toString()?.getSHA256withSalt()?.take(8),
+                                    gyro = gyroData,
+                                    accel = accelData,
+                                    attrs = attrJSON
+                                )
                             )
-                        )
+                    }
                 }
 
             }


### PR DESCRIPTION
Fixes the multiple copy/past problem when a user has a populated clipboard and then hit delete. The SDK will send paste events in this case for each deletion that occurs. The fix is to check that the item pasted is not empty before we send a paste event back to the server. 

Tests will be forthcoming in another PR. Thanks. 