### PR TITLE
ENG-6920 use new session commands fix

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -98,7 +98,6 @@ class NeuroID private constructor(
     companion object {
         var showLogs: Boolean = true
         var isSDKStarted = false
-        const val ENDPOINT_PRODUCTION = "https://receiver.neuroid.cloud/"
 
         private var singleton: NeuroID? = null
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -37,7 +37,6 @@ class NeuroID private constructor(
     internal var application: Application?, internal var clientKey: String
 ) {
     private var firstTime = true
-    private var endpoint = ENDPOINT_PRODUCTION
     internal var sessionID = ""
     internal var clientID = ""
     internal var userID = ""
@@ -427,7 +426,7 @@ class NeuroID private constructor(
             saveIntegrationHealthEvents()
         }
         application?.let {
-            nidJobServiceManager.startJob(it, clientKey, endpoint)
+            nidJobServiceManager.startJob(it, clientKey)
         }
         dataStore.saveAndClearAllQueuedEvents()
 
@@ -676,7 +675,7 @@ class NeuroID private constructor(
         isSDKStarted = true
         application?.let {
             if (!nidJobServiceManager.isSetup) {
-                nidJobServiceManager.startJob(it, clientKey, endpoint)
+                nidJobServiceManager.startJob(it, clientKey)
             } else {
                 nidJobServiceManager.restart()
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -173,8 +173,8 @@ class NeuroID private constructor(
 
     fun setRegisteredUserID(registeredUserId: String): Boolean {
         val result = setGenericUserID(SET_REGISTERED_USER_ID, registeredUserId)
-        return if (result) {
-            this.registeredUserID = registeredUserId
+        return if (result.originCode != NID_ORIGIN_CODE_FAIL) {
+            this.registeredUserID = result.sessionID
             true
         } else {
             false
@@ -185,21 +185,21 @@ class NeuroID private constructor(
         val result = setGenericUserID(
             SET_USER_ID, userId
         )
-        return if (result) {
-            this.userID = userId
+        return if (result.originCode != NID_ORIGIN_CODE_FAIL) {
+            this.userID = result.sessionID
             true
         } else {
             false
         }
     }
 
-    internal fun setGenericUserID(type: String, genericUserId: String): Boolean {
+    internal fun setGenericUserID(type: String, genericUserId: String): SessionIDOriginResult {
         try {
             val result = getOriginResult(genericUserId)
             sendOriginEvent(result)
 
             if (result.originCode == NID_ORIGIN_CODE_FAIL) {
-                return false
+                return result
             }
             val gyroData = NIDSensorHelper.getGyroscopeInfo()
             val accelData = NIDSensorHelper.getAccelerometerInfo()
@@ -225,10 +225,10 @@ class NeuroID private constructor(
             } else {
                 dataStore.queueEvent(genericUserIdEvent)
             }
-            return true
+            return result
         } catch (exception: Exception) {
             NIDLog.e(msg = "failure processing user id! $type, $genericUserId $exception")
-            return false
+            return SessionIDOriginResult("", NID_ORIGIN_CODE_FAIL, "")
         }
     }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.storage.NIDDataStoreManager
 import com.neuroid.tracker.storage.getDataStoreInstance
+import com.neuroid.tracker.utils.Constants
 import com.neuroid.tracker.utils.NIDLogWrapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +26,7 @@ object NIDJobServiceManager {
     var userActive = true
     internal var clientKey = ""
     private var application: Application? = null
-    internal var endpoint: String = ""
+    internal var endpoint = Constants.productionEndpoint.displayName
 
     internal var isSetup: Boolean = false
 
@@ -33,10 +34,8 @@ object NIDJobServiceManager {
     fun startJob(
         application: Application,
         clientKey: String,
-        endpoint: String
     ) {
         this.clientKey = clientKey
-        this.endpoint = endpoint
         this.application = application
         jobCaptureEvents = createJobServer()
         NIDSensorHelper.initSensorHelper(application, NIDLogWrapper())

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
@@ -7,5 +7,6 @@ enum class Constants(val displayName: String) {
     integrationHealthAssetsFolder("integrationHealth"),
 
     debugEventTag("Event"),
-    fpjsProdDomain("https://advanced.neuro-id.com")
+    fpjsProdDomain("https://advanced.neuro-id.com"),
+    productionEndpoint("https://receiver.neuroid.cloud/")
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/NIDJobServiceManagerTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NIDJobServiceManagerTest.kt
@@ -52,7 +52,7 @@ class NIDJobServiceManagerTest {
 
     @Test
     fun testGetApiService() {
-        NIDJobServiceManager.endpoint = "https://test.com"
+        NIDJobServiceManager.endpoint = Constants.productionEndpoint.displayName
         assertNotNull(NIDJobServiceManager.getServiceAPI())
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NIDJobServiceManagerTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NIDJobServiceManagerTest.kt
@@ -9,6 +9,7 @@ import com.neuroid.tracker.service.NIDEventSender
 import com.neuroid.tracker.service.NIDJobServiceManager
 import com.neuroid.tracker.service.NIDResponseCallBack
 import com.neuroid.tracker.storage.NIDDataStoreManager
+import com.neuroid.tracker.utils.Constants
 import com.neuroid.tracker.utils.NIDLogWrapper
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -31,7 +32,7 @@ class NIDJobServiceManagerTest {
         injectMockedApplication()
         assertEquals(NIDJobServiceManager.isSetup, true)
         assertEquals(NIDJobServiceManager.clientKey, "clientKey")
-        assertEquals(NIDJobServiceManager.endpoint, "https://test.com")
+        assertEquals(NIDJobServiceManager.endpoint,Constants.productionEndpoint.displayName)
         assertNotNull(NIDJobServiceManager.jobCaptureEvents)
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NIDJobServiceManagerTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NIDJobServiceManagerTest.kt
@@ -31,7 +31,7 @@ class NIDJobServiceManagerTest {
         injectMockedApplication()
         assertEquals(NIDJobServiceManager.isSetup, true)
         assertEquals(NIDJobServiceManager.clientKey, "clientKey")
-        assertEquals(NIDJobServiceManager.endpoint, "endpoint")
+        assertEquals(NIDJobServiceManager.endpoint, "https://test.com")
         assertNotNull(NIDJobServiceManager.jobCaptureEvents)
     }
 
@@ -129,7 +129,7 @@ class NIDJobServiceManagerTest {
         val sharedPreferences = mockk<SharedPreferences>()
         every {sharedPreferences.getString(any(), any())} returns "test"
         every { application.getSharedPreferences(any(), any()) } returns sharedPreferences
-        NIDJobServiceManager.startJob(application, "clientKey", "endpoint")
+        NIDJobServiceManager.startJob(application, "clientKey")
     }
 
     private fun getMockEventSender(isSuccess: Boolean,

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -855,6 +855,45 @@ open class NeuroIDClassUnitTests {
         }
     }
 
+    @Test
+    fun testSetRegisteredUserId_not_empty() {
+        unsetDefaultMockedLogger()
+        NeuroID.getInstance()?.let {
+            it.setRegisteredUserID("gdsgdsgsd")
+            assertEquals(it.getRegisteredUserID(), "gdsgdsgsd")
+        }
+    }
+
+    @Test
+    fun testSetRegisteredUserId_empty() {
+        unsetDefaultMockedLogger()
+        NeuroID.getInstance()?.let {
+            it.setRegisteredUserID("")
+            // should be random id
+            assertNotEquals(it.getRegisteredUserID(), "")
+        }
+    }
+
+    @Test
+    fun testSetUserId_not_empty() {
+        unsetDefaultMockedLogger()
+        NeuroID.getInstance()?.let {
+            it.setUserID("gdsgdsgsdzzzz")
+            assertEquals(it.getUserID(), "gdsgdsgsdzzzz")
+        }
+    }
+
+    @Test
+    fun testSetUserId_empty() {
+        unsetDefaultMockedLogger()
+        NeuroID.getInstance()?.let {
+            it.setUserID("")
+            // should be random id
+            assertNotEquals(it.getUserID(), "")
+        }
+    }
+
+
     fun unsetDefaultMockedLogger() {
         val log = mockk<NIDLogWrapper>()
         every {log.d(any(), any()) } just runs


### PR DESCRIPTION
This fix is for a crash that was found during sample app testing. 

If user calls startSession("bad session id") with a bad session id, then calls stopSession(), app will crash because the job manager was never initialized with the proper endpoint (empty) and will try to flush the empty queue causing retrofit to throw an invalid URL exception. To fix this, we statically set the URL to always point to production. This way it will always be set and the call to stopSession() will harmlessly flush an empty queue. 

Also the NeuroID.userID member variable was not being updated when the startSession("") was invoked with an empty id parameter causing getUserID() to return empty. This should have been updated with a random id. The user id was however being updated in the shared prefs and being sent back the server via server events. This was missed. This is fixed now. Tests were added to insure that any future changes made here will ensure that this still works. 
