### PR TITLE
ENG-6957 fix pauseCollection and resumeCollection concurrency issue

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -703,10 +703,14 @@ class NeuroID private constructor(
     @Synchronized
     fun pauseCollection() {
         isSDKStarted = false
-        pauseCollectionJob = CoroutineScope(Dispatchers.IO).launch {
-            nidJobServiceManager.sendEventsNow(NIDLogWrapper(), true)
-            nidJobServiceManager.stopJob()
-            saveIntegrationHealthEvents()
+        if (pauseCollectionJob == null ||
+            pauseCollectionJob?.isCancelled == true ||
+            pauseCollectionJob?.isCompleted == true) {
+            pauseCollectionJob = CoroutineScope(Dispatchers.IO).launch {
+                nidJobServiceManager.sendEventsNow(NIDLogWrapper(), true)
+                nidJobServiceManager.stopJob()
+                saveIntegrationHealthEvents()
+            }
         }
     }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -722,7 +722,12 @@ class NeuroID private constructor(
         // allow blocking for a max of 2 sec, else this could block forever
         // if something bad happens in pauseCollection() that doesn't trigger
         // the countdown
-        countDownLatch?.await(2000, TimeUnit.MILLISECONDS)
+        countDownLatch?.await(2000, TimeUnit.MILLISECONDS)?.let {
+            if (!it) {
+                NIDLog.e("pauseCollection() Issue", "pauseCollection() " +
+                        "didn't complete within 2 seconds. Unblock and continue. ")
+            }
+        }
         isSDKStarted = true
         application?.let {
             if (!nidJobServiceManager.isSetup) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -40,7 +40,7 @@ class NeuroID private constructor(
 ) {
     @Volatile
     // used to notify resumeCollection() to continue after pauseCollection() completes
-    internal var countDownLatch:CountDownLatch? = null
+    private var countDownLatch:CountDownLatch? = null
 
     private var firstTime = true
     internal var sessionID = ""
@@ -707,10 +707,13 @@ class NeuroID private constructor(
         countDownLatch = CountDownLatch(1)
         isSDKStarted = false
         CoroutineScope(Dispatchers.IO).launch {
-            nidJobServiceManager.sendEventsNow(NIDLogWrapper(), true)
-            nidJobServiceManager.stopJob()
-            saveIntegrationHealthEvents()
-            countDownLatch?.countDown()
+            try {
+                nidJobServiceManager.sendEventsNow(NIDLogWrapper(), true)
+                nidJobServiceManager.stopJob()
+                saveIntegrationHealthEvents()
+            } finally {
+                countDownLatch?.countDown()
+            }
         }
     }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -704,13 +704,9 @@ class NeuroID private constructor(
     fun pauseCollection() {
         isSDKStarted = false
         pauseCollectionJob = CoroutineScope(Dispatchers.IO).launch {
-            try {
-                nidJobServiceManager.sendEventsNow(NIDLogWrapper(), true)
-                nidJobServiceManager.stopJob()
-                saveIntegrationHealthEvents()
-            } finally {
-                pauseCollectionJob = null
-            }
+            nidJobServiceManager.sendEventsNow(NIDLogWrapper(), true)
+            nidJobServiceManager.stopJob()
+            saveIntegrationHealthEvents()
         }
     }
 


### PR DESCRIPTION
Fix pauseCollection and resumeCollection concurrency issue. See ENG-6957 ticket for details. 

https://neuro-id.atlassian.net/browse/ENG-6957

This is a quick run of the session methods in this order (instrumented build with log)
startSession() calls resumeCollection() internally. 

```
NeuroID.getInstance()?.startSession("gsdagasdgsd");
println("kurt_test ${NeuroID.getInstance()?.isStopped()}")
NeuroID.getInstance()?.pauseCollection()
NeuroID.getInstance()?.pauseCollection()
NeuroID.getInstance()?.pauseCollection()
NeuroID.getInstance()?.pauseCollection()
println("kurt_test ${NeuroID.getInstance()?.isStopped()}")
NeuroID.getInstance()?.resumeCollection()
println("kurt_test ${NeuroID.getInstance()?.isStopped()}")

// startSession()
2024-01-12 13:08:28.389 1 kurt_test no completion handler resumeCollection()
2024-01-12 13:08:28.414 1 kurt_test no completion handler resumeCollectionCompletion() done resumeCollection()
2024-01-12 13:08:28.416 1 kurt_test false
// pauseCollection() 1
2024-01-12 13:08:28.416 1 kurt_test start pauseCollection()
// pauseCollection() 2 -> ignored
2024-01-12 13:08:28.418 1 kurt_test start pauseCollection()
2024-01-12 13:08:28.418 1 kurt_test ignored pauseCollection() in progress
// pauseCollection() 3 -> ignored
2024-01-12 13:08:28.418 1 kurt_test start pauseCollection()
2024-01-12 13:08:28.419 1 kurt_test in thread pauseCollection()
2024-01-12 13:08:28.419 1 kurt_test ignored pauseCollection() in progress
// pauseCollection() 4 -> ignored
2024-01-12 13:08:28.419 1 kurt_test start pauseCollection()
2024-01-12 13:08:28.419 1 kurt_test ignored pauseCollection() in progress
2024-01-12 13:08:28.419 1 kurt_test true
// resumeCollection() 
2024-01-12 13:08:28.419 1 kurt_test start resumeCollection()
2024-01-12 13:08:28.420 1 kurt_test true
// resumeCollection() is now blocked pending pauseCollection() completion
2024-01-12 13:08:28.958 1 kurt_test sendEventsNow() done pauseCollection()
2024-01-12 13:08:28.963 1 kurt_test stopJob() done pauseCollection()
2024-01-12 13:08:28.963 1 kurt_test saveIntegrationHealthEvents() done pauseCollection()
// first pauseCollection() 1 done!
2024-01-12 13:08:28.963 1 kurt_test completion handler resumeCollection()
// resumeCollecton() done! 
2024-01-12 13:08:28.988 1 kurt_test resumeCollectionCompletion() done resumeCollection()

```