### PR TITLE
ENG-6176-checkout master branch to get the latest tag

### DIFF
--- a/.github/workflows/github-actions-master-push-assamble.yml
+++ b/.github/workflows/github-actions-master-push-assamble.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-tags: true
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -49,9 +52,7 @@ jobs:
         run: bash ./gradlew :NeuroID:assemble
 
       - name: Get last version from tags
-        run: |
-          git fetch --prune --unshallow
-          echo "VERSION=$(git describe --tag --abbrev=0)" >> $GITHUB_ENV
+        run: echo "VERSION=$(git describe --tag --abbrev=0)" >> $GITHUB_ENV
 
       - name: Trigger Android Sandbox Prod Deployment
         run: |


### PR DESCRIPTION
In the recent prod deploy the latest tag used to deploy sandbox apps were not the latest since the branch checked out was the release PR. Adding a fix to checkout the main branch and its related tags.