### PR TITLE
[ENG-7171] synchronize send events

### DIFF
--- a/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/debug/java/com/neuroid/tracker/NeuroID.kt
@@ -281,7 +281,7 @@ class NeuroID private constructor(
     fun stop() {
         this.isSDKStarted = false
         CoroutineScope(Dispatchers.IO).launch {
-            NIDJobServiceManager.sendEventsNow(true)
+            NIDJobServiceManager.sendEvents(true)
             NIDJobServiceManager.stopJob()
             saveIntegrationHealthEvents()
         }

--- a/NeuroID/src/debug/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
+++ b/NeuroID/src/debug/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
@@ -13,9 +13,6 @@ import com.neuroid.tracker.utils.Constants
 import com.neuroid.tracker.utils.NIDLog
 import com.neuroid.tracker.utils.NIDTimerActive
 import com.neuroid.tracker.utils.NIDVersion
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -78,14 +75,10 @@ private object NIDDataStoreManagerImp: NIDDataStoreManager {
 
         when (event.type) {
             BLUR -> {
-                CoroutineScope(Dispatchers.IO).launch {
-                    NIDJobServiceManager.sendEventsNow()
-                }
+                NIDJobServiceManager.sendEvents()
             }
             CLOSE_SESSION -> {
-                CoroutineScope(Dispatchers.IO).launch {
-                    NIDJobServiceManager.sendEventsNow(true)
-                }
+                NIDJobServiceManager.sendEvents(true)
             }
         }
     }

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -2,9 +2,11 @@ package com.neuroid.tracker.service
 
 import android.app.Application
 import com.neuroid.tracker.callbacks.NIDSensorHelper
+import com.neuroid.tracker.utils.NIDLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -12,6 +14,7 @@ import kotlinx.coroutines.launch
 object NIDJobServiceManager {
 
     private var jobCaptureEvents: Job? = null
+    private var jobSendEvents: Job? = null
     var isSendEventsNowEnabled = true
 
     @Volatile
@@ -19,6 +22,8 @@ object NIDJobServiceManager {
     private var clientKey = ""
     private var application: Application? = null
     private var endpoint: String = ""
+
+    private val sendEventsNotification = Channel<Boolean>(Channel.UNLIMITED)
 
     @Synchronized
     fun startJob(
@@ -30,6 +35,7 @@ object NIDJobServiceManager {
         this.endpoint = endpoint
         this.application = application
         jobCaptureEvents = createJobServer()
+        jobSendEvents = createSendEventsServer()
         NIDSensorHelper.initSensorHelper(application)
     }
 
@@ -40,16 +46,49 @@ object NIDJobServiceManager {
         jobCaptureEvents = createJobServer()
     }
 
+    /**
+     * Creates a job that synchronizes all requests to send events.
+     */
+    private fun createSendEventsServer(): Job {
+        return CoroutineScope(Dispatchers.IO).launch {
+            try {
+            for (notification in sendEventsNotification) {
+                var sendNow = notification
+                var next = sendEventsNotification.tryReceive()
+                while (next.isSuccess) {
+                    next.getOrNull()?.let {
+                        sendNow = sendNow || it
+                    }
+                    next = sendEventsNotification.tryReceive()
+                }
+                sendEventsNow(sendNow)
+            }
+            } catch (exception: Exception) {
+                NIDLog.e("NeuroID", exception.toString())
+            }
+            NIDLog.e("NeuroID", "send event job exited")
+        }
+    }
+
     private fun createJobServer(): Job {
         return CoroutineScope(Dispatchers.IO).launch {
             while (userActive && isActive) {
                 delay(5000L)
-                sendEventsNow()
+                sendEventsNotification.send(false)
             }
         }
     }
 
-    suspend fun sendEventsNow(forceSendEvents: Boolean = false) {
+    /**
+     * Notify the send events server to initiate a send.
+     */
+    fun sendEvents(forceSendEvents: Boolean = false) {
+        CoroutineScope(Dispatchers.IO).launch {
+            sendEventsNotification.send(forceSendEvents)
+        }
+    }
+
+    private suspend fun sendEventsNow(forceSendEvents: Boolean = false) {
         if (forceSendEvents || (isSendEventsNowEnabled && !isStopped())) {
             application?.let {
                 val response = NIDServiceTracker.sendEventToServer(clientKey, endpoint, it)

--- a/NeuroID/src/release/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/release/java/com/neuroid/tracker/NeuroID.kt
@@ -282,7 +282,7 @@ class NeuroID private constructor(
     fun stop() {
         this.isSDKStarted = false
         CoroutineScope(Dispatchers.IO).launch {
-            NIDJobServiceManager.sendEventsNow(true)
+            NIDJobServiceManager.sendEvents(true)
             NIDJobServiceManager.stopJob()
             saveIntegrationHealthEvents()
         }

--- a/NeuroID/src/release/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
+++ b/NeuroID/src/release/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
@@ -78,14 +78,10 @@ private object NIDDataStoreManagerImp: NIDDataStoreManager {
 
         when (event.type) {
             BLUR -> {
-                CoroutineScope(Dispatchers.IO).launch {
-                    NIDJobServiceManager.sendEventsNow()
-                }
+                NIDJobServiceManager.sendEvents()
             }
             CLOSE_SESSION -> {
-                CoroutineScope(Dispatchers.IO).launch {
-                    NIDJobServiceManager.sendEventsNow(true)
-                }
+                NIDJobServiceManager.sendEvents(true)
             }
         }
     }


### PR DESCRIPTION
Adds a new service to synchronize calls to `NIDServiceTracker.sendEventToServer` using a `Channel` to receive notifications.  The original service now generates notifications on the time interval and other calls to `sendEventToServer` were replaced with notifications.