### PR TITLE
ENG-7027-Include Read Phone state permission in sdk manifest

### DIFF
--- a/NeuroID/src/main/AndroidManifest.xml
+++ b/NeuroID/src/main/AndroidManifest.xml
@@ -5,4 +5,5 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 </manifest>


### PR DESCRIPTION
Adding READ_PHONE_STATE permission into SDK manifest for customer awareness.