### PR TITLE
ENG-7467 various bug fixes, android

### DIFF
--- a/NeuroID/src/advancedDeviceLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/advancedDeviceLib/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -30,7 +30,7 @@ fun NeuroID.start(advancedDeviceSignals: Boolean): Boolean {
 }
 
 fun NeuroID.startSession(
-    sessionID: String = "",
+    sessionID: String? = null,
     advancedDeviceSignals: Boolean
 ): SessionStartResult {
     val sessionRes = startSession(

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -685,6 +685,10 @@ class NeuroID
 
         @Synchronized
         fun resumeCollection() {
+            // Don't allow resume to be called if SDK has not been started
+            if (userID.isEmpty() && !isSDKStarted) {
+                return
+            }
             if (pauseCollectionJob?.isCompleted == true ||
                 pauseCollectionJob?.isCancelled == true ||
                 pauseCollectionJob == null

--- a/NeuroID/src/main/java/com/neuroid/tracker/events/TouchEventManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/events/TouchEventManager.kt
@@ -132,14 +132,14 @@ class TouchEventManager(
                 when (currentView) {
                     is CheckBox, is AppCompatCheckBox -> {
                         type = CHECKBOX_CHANGE
-                        logger.i(
+                        logger.d(
                             NIDLog.CHECK_BOX_CHANGE_TAG,
                             NIDLog.CHECK_BOX_ID + currentView.getIdOrTag(),
                         )
                     }
                     is RadioButton -> {
                         type = RADIO_CHANGE
-                        logger.i(
+                        logger.d(
                             NIDLog.RADIO_BUTTON_CHANGE_TAG,
                             NIDLog.RADIO_BUTTON_ID + currentView.getIdOrTag(),
                         )

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDNetworkListener.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDNetworkListener.kt
@@ -36,11 +36,13 @@ class NIDNetworkListener(
         private val dataStoreManager: NIDDataStoreManager,
         private val neuroID: NeuroID,
         private val dispatcher: CoroutineContext,
-        private val sleepInterval: Long = SLEEP_INTERVAL
+        private val sleepIntervalResume: Long = SLEEP_INTERVAL_RESUME,
+        private val sleepIntervalPause: Long = SLEEP_INTERVAL_PAUSE
 ) : BroadcastReceiver() {
 
     companion object {
-        const val SLEEP_INTERVAL = 10000L
+        const val SLEEP_INTERVAL_PAUSE = 10000L
+        const val SLEEP_INTERVAL_RESUME = 2000L
     }
 
     private var haveNoNetworkJob: Job? = null
@@ -70,7 +72,7 @@ class NIDNetworkListener(
             }
             haveNoNetworkJob =
                     CoroutineScope(dispatcher).launch {
-                        delay(sleepInterval)
+                        delay(sleepIntervalPause)
                         neuroID.pauseCollection(false)
                     }
         } else {
@@ -79,7 +81,7 @@ class NIDNetworkListener(
             }
             haveNetworkJob =
                     CoroutineScope(dispatcher).launch {
-                        delay(sleepInterval)
+                        delay(sleepIntervalResume)
                         neuroID.resumeCollection()
                     }
         }

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt
@@ -84,7 +84,6 @@ class NIDTextWatcher(
 
         if (lastHashValue != currentHashValue) {
             lastHashValue = sequence?.toString()?.getSHA256withSalt()?.take(8)
-            logger.d(msg = "Activity - after text $sequence")
 
             neuroID.captureEvent(
                 type = INPUT,

--- a/NeuroID/src/test/java/com/neuroid/tracker/NIDNetworkListenerTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NIDNetworkListenerTest.kt
@@ -164,7 +164,7 @@ class NIDNetworkListenerTest {
         val intent = mockk<Intent>()
         every { intent.action } returns ConnectivityManager.CONNECTIVITY_ACTION
         val listener = NIDNetworkListener(connectivityManager, dataStoreManager, neuroID,
-            UnconfinedTestDispatcher(), 0
+            UnconfinedTestDispatcher(), 0, 0
         )
         listener.onReceive(context, intent)
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -883,6 +883,44 @@ open class NeuroIDClassUnitTests {
     @Test
     fun testResumeCollection() {
         setMockedNIDJobServiceManager()
+        NeuroID.getInstance()?.pauseCollection()
+        NeuroID.getInstance()?.let {
+            it.resumeCollection()
+
+            if (it.pauseCollectionJob != null) {
+                it.pauseCollectionJob?.invokeOnCompletion {
+                    assertEquals(true, NeuroID.isSDKStarted)
+                }
+            } else {
+                assertEquals(true, NeuroID.isSDKStarted)
+            }
+
+        }
+    }
+
+    @Test
+    fun testResumeCollection_SDK_is_stopped_no_userId() {
+        setMockedNIDJobServiceManager()
+        NeuroID.getInstance()?.stopSession()
+        NeuroID.getInstance()?.let {
+            it.resumeCollection()
+
+            if (it.pauseCollectionJob != null) {
+                it.pauseCollectionJob?.invokeOnCompletion {
+                    assertEquals(false, NeuroID.isSDKStarted)
+                }
+            } else {
+                assertEquals(false, NeuroID.isSDKStarted)
+            }
+
+        }
+    }
+
+    @Test
+    fun testResumeCollection_SDK_is_stopped_userId() {
+        setMockedNIDJobServiceManager()
+        NeuroID.getInstance()?.stopSession()
+        NeuroID.getInstance()?.setUserID("gasdgasdgasd")
         NeuroID.getInstance()?.let {
             it.resumeCollection()
 


### PR DESCRIPTION
startSession in advanced library fix to allow null sessionID in startSession

change delay interval from 10s to 2s in network listener 

removed text watch debug` logger.d(msg = "Activity - after text $sequence")`

Don't allow resume to be called if SDK has not been started

change log level to debug for TouchEvent items. 