### PR TITLE
ENG 7530 remote config

### DIFF
--- a/NeuroID/src/advancedDeviceLib/java/com/neuroid/tracker/service/NIDAdvancedDeviceNetworkService.kt
+++ b/NeuroID/src/advancedDeviceLib/java/com/neuroid/tracker/service/NIDAdvancedDeviceNetworkService.kt
@@ -21,6 +21,7 @@ class NIDAdvancedDeviceNetworkService(
     companion object {
         const val RETRY_COUNT = 3
         const val TIMEOUT = 2L // 2000L = 2 sec?
+        const val HTTP_SUCCESS = 200
     }
 
     override fun getNIDAdvancedDeviceAccessKey(
@@ -48,7 +49,7 @@ class NIDAdvancedDeviceNetworkService(
 
                 // only allow 200 codes to succeed, everything else is failure, 204 is a failure
                 // which is weird!
-                if (response.code() == NIDEventSender.HTTP_SUCCESS) {
+                if (response.code() == HTTP_SUCCESS) {
                     val responseBody = response.body()
 
                     // Shouldn't be possible but retrofit says body can be null

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -199,7 +199,7 @@ class NeuroID
             internal var registeredViews: MutableSet<String> = mutableSetOf()
 
             internal var endpoint = "${Constants.productionEndpoint.displayName}"
-            internal var scriptEndpoint = "${Constants.productionScriptsEndpoint.displayName}"
+            internal var scriptEndpoint = "${Constants.devScriptsEndpoint.displayName}"
             private var singleton: NeuroID? = null
 
             // configuration state

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -6,7 +6,7 @@ data class NIDRemoteConfig(
     @SerializedName(value="call_in_progress")
     val callInProgress: Boolean = true,
     @SerializedName(value="event_queue_flush_interval")
-    val eventQueueFlushInterval: Long = 10,
+    val eventQueueFlushInterval: Long = 5,
     @SerializedName(value="event_queue_flush_size")
     val eventQueueFlushSize: Int = 1999,
     @SerializedName(value="geo_location")

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -8,7 +8,7 @@ data class NIDRemoteConfig(
     @SerializedName(value="event_queue_flush_interval")
     val eventQueueFlushInterval: Long = 10,
     @SerializedName(value="event_queue_flush_size")
-    val eventQueueFlushSize: Int = 2000,
+    val eventQueueFlushSize: Int = 1999,
     @SerializedName(value="geo_location")
     val geoLocation: Boolean = true,
     @SerializedName(value="gyro_accel_cadence")

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -1,0 +1,20 @@
+package com.neuroid.tracker.models
+
+import com.google.gson.annotations.SerializedName
+
+data class NIDRemoteConfig(
+    @SerializedName(value="call_in_progress")
+    val callInProgress: Boolean = true,
+    @SerializedName(value="event_queue_flush_interval")
+    val eventQueueFlushInterval: Long = 10,
+    @SerializedName(value="event_queue_flush_size")
+    val eventQueueFlushSize: Int = 2000,
+    @SerializedName(value="geo_location")
+    val geoLocation: Boolean = true,
+    @SerializedName(value="gyro_accel_cadence")
+    val gyroAccelCadence: Boolean = false,
+    @SerializedName(value="gyro_accel_cadence_time")
+    val gyroAccelCadenceTime: Long = 200L,
+    @SerializedName(value="request_timeout")
+    val requestTimeout: Long = 10) {
+}

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDApiService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDApiService.kt
@@ -1,9 +1,11 @@
 package com.neuroid.tracker.service
 
+import com.neuroid.tracker.models.NIDRemoteConfig
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -13,4 +15,9 @@ interface NIDApiService {
         @Body requestBody: RequestBody,
         @Path("key") key: String,
     ): Call<ResponseBody>
+
+    @GET("/mobile/{key}.json")
+    fun getConfig(
+        @Path("key") key: String
+    ): Call<NIDRemoteConfig>
 } 

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDConfigurationService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDConfigurationService.kt
@@ -1,0 +1,33 @@
+package com.neuroid.tracker.service
+
+import com.neuroid.tracker.models.NIDRemoteConfig
+
+class NIDConfigurationService(
+    apiService: NIDApiService,
+    remoteConfigListener: OnRemoteConfigReceivedListener,
+    key: String
+): RetrySender() {
+
+    var nidRemoteConfig = NIDRemoteConfig()
+
+    private val responseCallback = object: NIDResponseCallBack {
+        override fun <T> onSuccess(code: Int, response: T) {
+            nidRemoteConfig = response as NIDRemoteConfig
+            remoteConfigListener.onRemoteConfigReceived(nidRemoteConfig)
+        }
+
+        override fun onFailure(code: Int, message: String, isRetry: Boolean) {
+            remoteConfigListener.onRemoteConfigReceivedFailed("no can get config for key: $key, use defaults")
+        }
+
+    }
+    init {
+        val call = apiService.getConfig(key)
+        retryRequests(call, responseCallback)
+    }
+}
+
+interface OnRemoteConfigReceivedListener {
+    fun onRemoteConfigReceived(remoteConfig: NIDRemoteConfig)
+    fun onRemoteConfigReceivedFailed(errorMessage: String)
+}

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDConfigurationService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDConfigurationService.kt
@@ -8,12 +8,9 @@ class NIDConfigurationService(
     key: String
 ): RetrySender() {
 
-    var nidRemoteConfig = NIDRemoteConfig()
-
     private val responseCallback = object: NIDResponseCallBack {
         override fun <T> onSuccess(code: Int, response: T) {
-            nidRemoteConfig = response as NIDRemoteConfig
-            remoteConfigListener.onRemoteConfigReceived(nidRemoteConfig)
+            remoteConfigListener.onRemoteConfigReceived(response as NIDRemoteConfig)
         }
 
         override fun onFailure(code: Int, message: String, isRetry: Boolean) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDConfigurationService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDConfigurationService.kt
@@ -14,7 +14,7 @@ class NIDConfigurationService(
         }
 
         override fun onFailure(code: Int, message: String, isRetry: Boolean) {
-            remoteConfigListener.onRemoteConfigReceivedFailed("no can get config for key: $key, use defaults")
+            remoteConfigListener.onRemoteConfigReceivedFailed("Unable to retrieve the remote configuration for key $key. The default values will be used instead")
         }
 
     }

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import okhttp3.ResponseBody
 
 internal class NIDJobServiceManager(
     private var neuroID: NeuroID,
@@ -171,7 +172,7 @@ internal class NIDJobServiceManager(
                     clientKey,
                     getEventsToSend(it),
                     object : NIDResponseCallBack {
-                        override fun onSuccess(code: Int) {
+                        override fun <T> onSuccess(code: Int, response: T) {
                             logger.d(msg = " network success, sendEventsNow() success userActive: $userActive")
                         }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -5,7 +5,6 @@ import android.app.Application
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.neuroid.tracker.NeuroID
-import com.neuroid.tracker.NeuroID.Companion.GYRO_SAMPLE_INTERVAL
 import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.events.CADENCE_READING_ACCEL
 import com.neuroid.tracker.events.LOW_MEMORY
@@ -20,7 +19,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import okhttp3.ResponseBody
 
 internal class NIDJobServiceManager(
     private var neuroID: NeuroID,
@@ -134,7 +132,7 @@ internal class NIDJobServiceManager(
     private fun createSendCadenceServer(): Job {
         return CoroutineScope(dispatcher).launch {
             while (userActive && isActive) {
-                delay(5000L)
+                delay(NeuroID.nidSDKConfig.eventQueueFlushInterval * 1000L)
                 sendEventsNotification.send(false)
             }
         }
@@ -145,15 +143,15 @@ internal class NIDJobServiceManager(
      */
     private fun createGyroCadenceServer(): Job {
         return CoroutineScope(dispatcher).launch {
-            while (NeuroID.isSDKStarted && NeuroID.captureGyroCadence) {
-                delay(NeuroID.GYRO_SAMPLE_INTERVAL)
+            while (NeuroID.isSDKStarted && NeuroID.nidSDKConfig.gyroAccelCadence) {
+                delay(NeuroID.nidSDKConfig.gyroAccelCadenceTime * 1000L)
 
                 neuroID.captureEvent(
                     type = CADENCE_READING_ACCEL,
                     attrs =
                         listOf(
                             mapOf(
-                                "interval" to "${1000 * GYRO_SAMPLE_INTERVAL}s",
+                                "interval" to "${NeuroID.nidSDKConfig.gyroAccelCadenceTime}sec",
                             ),
                         ),
                 )

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -144,7 +144,7 @@ internal class NIDJobServiceManager(
     private fun createGyroCadenceServer(): Job {
         return CoroutineScope(dispatcher).launch {
             while (NeuroID.isSDKStarted && NeuroID.nidSDKConfig.gyroAccelCadence) {
-                delay(NeuroID.nidSDKConfig.gyroAccelCadenceTime * 1000L)
+                delay(NeuroID.nidSDKConfig.gyroAccelCadenceTime)
 
                 neuroID.captureEvent(
                     type = CADENCE_READING_ACCEL,

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDResponseCallBack.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDResponseCallBack.kt
@@ -1,7 +1,5 @@
 package com.neuroid.tracker.service
 
-import retrofit2.Response
-
 interface NIDResponseCallBack {
     fun <T> onSuccess(code: Int, response: T)
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDResponseCallBack.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDResponseCallBack.kt
@@ -1,7 +1,9 @@
 package com.neuroid.tracker.service
 
+import retrofit2.Response
+
 interface NIDResponseCallBack {
-    fun onSuccess(code: Int)
+    fun <T> onSuccess(code: Int, response: T)
 
     fun onFailure(
         code: Int,

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/RetrySender.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/RetrySender.kt
@@ -1,0 +1,46 @@
+package com.neuroid.tracker.service
+
+import retrofit2.Call
+
+abstract class RetrySender {
+    companion object {
+        // if you change the retry count, please update the test!
+        const val RETRY_COUNT = 3
+        const val HTTP_SUCCESS = 200
+    }
+
+    fun <T> retryRequests(
+        call: Call<T>,
+        responseCallback: NIDResponseCallBack,
+    )  {
+        try {
+            var retryCount = 0
+            while (retryCount < RETRY_COUNT) {
+                // retain the existing call and always execute on clones of it so we can retry when
+                // there is a failure!
+                val retryCall = call.clone()
+                val response = retryCall.execute()
+                // only allow 200 codes to succeed, everything else is failure, 204 is a failure
+                // which is weird!
+                if (response.code() == HTTP_SUCCESS) {
+                    responseCallback.onSuccess(response.code(), response.body())
+                    break
+                } else {
+                    // response code is not 200, retry these up to RETRY_COUNT times
+                    retryCount++
+                    responseCallback.onFailure(
+                        response.code(),
+                        response.message(),
+                        retryCount < RETRY_COUNT,
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            var errorMessage = "no error message available"
+            e.message?.let {
+                errorMessage = it
+            }
+            responseCallback.onFailure(-1, errorMessage, false)
+        }
+    }
+}

--- a/NeuroID/src/main/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt
@@ -33,7 +33,7 @@ internal class NIDDataStoreManagerImp(
     val logger: NIDLogWrapper,
 ) : NIDDataStoreManager {
     companion object {
-        private const val EVENT_BUFFER_MAX_COUNT = 1999
+        private var eventBufferMaxCount = NeuroID.nidSDKConfig.eventQueueFlushSize
 
         private val listNonActiveEvents =
             listOf(
@@ -148,7 +148,7 @@ internal class NIDDataStoreManagerImp(
 
         if (lastEventType == FULL_BUFFER) {
             return true
-        } else if (eventsList.size + queuedEvents.size > EVENT_BUFFER_MAX_COUNT) {
+        } else if (eventsList.size + queuedEvents.size > eventBufferMaxCount) {
             // add a full buffer event and drop the new event
             saveEvent(
                 NIDEventModel(type = FULL_BUFFER, ts = System.currentTimeMillis()),

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
@@ -8,6 +8,6 @@ enum class Constants(val displayName: String) {
 
     debugEventTag("Event"),
     fpjsProdDomain("https://advanced.neuro-id.com"),
-    productionEndpoint("https://receiver.neuroid.cloud/"),
-    devEndpoint("https://receiver.neuro-dev.com/"),
+    productionEndpoint("neuroid.cloud/"),
+    devEndpoint("neuro-dev.com/")
 } 

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
@@ -8,6 +8,8 @@ enum class Constants(val displayName: String) {
 
     debugEventTag("Event"),
     fpjsProdDomain("https://advanced.neuro-id.com"),
-    productionEndpoint("neuroid.cloud/"),
-    devEndpoint("neuro-dev.com/")
+    productionEndpoint("https://receiver.neuroid.cloud/"),
+    productionScriptsEndpoint("http://scripts.neuro-id.com/"),
+    devEndpoint("https://receiver.neuro-dev.com/"),
+    devScriptsEndpoint("http://scripts.neuro-dev.com/")
 } 

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/RetrofitInstantiator.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/RetrofitInstantiator.kt
@@ -1,5 +1,6 @@
 package com.neuroid.tracker.utils
 
+import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.service.LoggerIntercepter
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -10,7 +11,7 @@ fun <T> getRetroFitInstance(
     endpoint: String,
     logger: NIDLogWrapper,
     service: Class<T>,
-    timeOut: Long = 10,
+    timeOut: Long = NeuroID.nidSDKConfig.requestTimeout,
 ): T =
     Retrofit.Builder()
         .baseUrl(endpoint)

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NeuroIDSendEventTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NeuroIDSendEventTest.kt
@@ -39,7 +39,7 @@ class NeuroIDSendEventTest {
 
         eventSender.sendEvents("test_key", events, callback)
         verify {
-            callback.onSuccess(200)
+            callback.onSuccess(200, null)
         }
     }
 
@@ -128,7 +128,7 @@ class NeuroIDSendEventTest {
         eventSender.retryRequests(mockedCall, callback)
 
         verify {
-            callback.onSuccess(200)
+            callback.onSuccess(200, null)
         }
 
     }
@@ -252,7 +252,7 @@ class NeuroIDSendEventTest {
 
     private fun getMockedNIDCallback():NIDResponseCallBack{
         val callback = mockk<NIDResponseCallBack>()
-        every { callback.onSuccess(any()) } just Runs
+        every { callback.onSuccess(any(), null) } just Runs
         every { callback.onFailure(any(), any(), any()) } just Runs
 
         return callback

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NeuroIDSendEventTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NeuroIDSendEventTest.kt
@@ -39,7 +39,7 @@ class NeuroIDSendEventTest {
 
         eventSender.sendEvents("test_key", events, callback)
         verify {
-            callback.onSuccess(200, null)
+            callback.onSuccess(200, any<ResponseBody>())
         }
     }
 
@@ -128,9 +128,8 @@ class NeuroIDSendEventTest {
         eventSender.retryRequests(mockedCall, callback)
 
         verify {
-            callback.onSuccess(200, null)
+            callback.onSuccess(200, any<ResponseBody>())
         }
-
     }
 
     @Test

--- a/app/src/androidTest/java/com/sample/neuroid/us/MockServerTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/MockServerTest.kt
@@ -124,14 +124,17 @@ abstract class MockServerTest {
             for (i in 0 until request) {
                 var req = server.takeRequest()
                 val body = req.body.readUtf8()
-                val gson = GsonBuilder()
-                    .registerTypeAdapter(LocationListener::class.java, LocationListenerCreator())
-                    .registerTypeAdapter(CoroutineScope::class.java, CoroutineScopeAdapter())
-                    .create()
-                val reader = gson.newJsonReader(StringReader(body))
-                reader?.let {
-                    processJSONObject(it, eventType)
+                if (body.contains(eventType)) {
+                    booleanIsFound = true
                 }
+//                val gson = GsonBuilder()
+//                    .registerTypeAdapter(LocationListener::class.java, LocationListenerCreator())
+//                    .registerTypeAdapter(CoroutineScope::class.java, CoroutineScopeAdapter())
+//                    .create()
+//                val reader = gson.newJsonReader(StringReader(body))
+//                reader?.let {
+//                    processJSONObject(it, eventType)
+//                }
             }
 
             if (booleanIsFound) {

--- a/app/src/androidTest/java/com/sample/neuroid/us/MockServerTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/MockServerTest.kt
@@ -124,17 +124,14 @@ abstract class MockServerTest {
             for (i in 0 until request) {
                 var req = server.takeRequest()
                 val body = req.body.readUtf8()
-                if (body.contains(eventType)) {
-                    booleanIsFound = true
+                val gson = GsonBuilder()
+                    .registerTypeAdapter(LocationListener::class.java, LocationListenerCreator())
+                    .registerTypeAdapter(CoroutineScope::class.java, CoroutineScopeAdapter())
+                    .create()
+                val reader = gson.newJsonReader(StringReader(body))
+                reader?.let {
+                    processJSONObject(it, eventType)
                 }
-//                val gson = GsonBuilder()
-//                    .registerTypeAdapter(LocationListener::class.java, LocationListenerCreator())
-//                    .registerTypeAdapter(CoroutineScope::class.java, CoroutineScopeAdapter())
-//                    .create()
-//                val reader = gson.newJsonReader(StringReader(body))
-//                reader?.let {
-//                    processJSONObject(it, eventType)
-//                }
             }
 
             if (booleanIsFound) {


### PR DESCRIPTION
Corrected branch name just now.
 
Update the app to use the client key: "key_live_IjLua9hEui4X5SlhlqFomaXE" to pull the the remote config from S3. If the app cannot pull the config for any reason, the app will default to the following config: 

```
data class NIDRemoteConfig(
    @SerializedName(value="call_in_progress")
    val callInProgress: Boolean = true,
    @SerializedName(value="event_queue_flush_interval")
    val eventQueueFlushInterval: Long = 10,
    @SerializedName(value="event_queue_flush_size")
    val eventQueueFlushSize: Int = 1999,
    @SerializedName(value="geo_location")
    val geoLocation: Boolean = true,
    @SerializedName(value="gyro_accel_cadence")
    val gyroAccelCadence: Boolean = false,
    @SerializedName(value="gyro_accel_cadence_time")
    val gyroAccelCadenceTime: Long = 200L,
    @SerializedName(value="request_timeout")
    val requestTimeout: Long = 10) {
}

```