### PR TITLE
ENG-6882 save LOG event when sendEventsNow fail.

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -3,10 +3,13 @@ package com.neuroid.tracker.service
 import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
+import android.media.metrics.Event
 import androidx.annotation.VisibleForTesting
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.events.CADENCE_READING_ACCEL
+import com.neuroid.tracker.events.ERROR
+import com.neuroid.tracker.events.LOG
 import com.neuroid.tracker.events.LOW_MEMORY
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.storage.NIDDataStoreManager
@@ -179,6 +182,7 @@ internal class NIDJobServiceManager(
                             message: String,
                             isRetry: Boolean,
                         ) {
+                            neuroID.captureEvent(type=LOG, m="network failure, sendEventsNow() failed retrylimitHit: $message $code")
                             logger.e(msg = "network failure, sendEventsNow() failed retrylimitHit: ${!isRetry} $message")
                         }
                     },

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -3,12 +3,10 @@ package com.neuroid.tracker.service
 import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
-import android.media.metrics.Event
 import androidx.annotation.VisibleForTesting
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.events.CADENCE_READING_ACCEL
-import com.neuroid.tracker.events.ERROR
 import com.neuroid.tracker.events.LOG
 import com.neuroid.tracker.events.LOW_MEMORY
 import com.neuroid.tracker.models.NIDEventModel


### PR DESCRIPTION
Send Log Event indicating the sendEventsNow() failed due to some error (either server or no network). Event will be saved and sent when the server/network is available and the buffer is not full. 

from proxy after network is restored and events are sent to server: 
`,"m":"network failure, sendEventsNow() failed retrylimitHit: Unable to resolve host \"receiver.neuro-dev.com\": No address associated with hostname -1","ts":1712010263592,"type":"LOG"`