### PR TITLE
ENG-7530 update integration tests to use dev script endpoints

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -265,6 +265,7 @@ class NeuroID
         @VisibleForTesting
         fun setTestingNeuroIDDevURL() {
             endpoint = Constants.devEndpoint.displayName
+            scriptEndpoint = Constants.devScriptsEndpoint.displayName
 
             application?.let {
                 nidJobServiceManager.setTestEventSender(getSendingService(endpoint, logger, it))

--- a/app/src/androidTest/java/com/sample/neuroid/us/ComponentsTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/ComponentsTest.kt
@@ -36,6 +36,9 @@ class ComponentsTest {
      */
     @Before
     fun stopSendEventsToServer() = runTest {
+        // set dev to scripts and collection endpoint
+        NeuroID.getInstance()?.setTestingNeuroIDDevURL()
+
         NeuroID.getInstance()?.isStopped()?.let {
             if (it) {
                 NeuroID.getInstance()?.start()

--- a/app/src/androidTest/java/com/sample/neuroid/us/MockServerTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/MockServerTest.kt
@@ -29,6 +29,8 @@ abstract class MockServerTest {
 
     @Before
     fun stopSendEventsToServer() = runTest {
+        // set dev to scripts and collection endpoint
+        NeuroID.getInstance()?.setTestingNeuroIDDevURL()
         server.start()
         val url = server.url("/c/").toString()
         NeuroID.getInstance()?.setTestURL(url)

--- a/app/src/androidTest/java/com/sample/neuroid/us/SandBoxTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/SandBoxTest.kt
@@ -28,6 +28,13 @@ import org.junit.runners.MethodSorters
 @ExperimentalCoroutinesApi
 class SandBoxTest {
 
+    @Before
+    fun init() {
+        // set dev to scripts and collection endpoint
+        NeuroID.getInstance()?.setTestingNeuroIDDevURL()
+    }
+
+
     @get:Rule
     var activityRule: ActivityScenarioRule<SandBoxActivity> =
         ActivityScenarioRule(SandBoxActivity::class.java)


### PR DESCRIPTION
initialize integration tests to use dev script endpoints before running tests.  