### PR TITLE
ENG-7530, set environment earlier

### DIFF
--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 
     reactNativeImplementation("com.facebook.react:react-native:0.71.0-rc.0")
 
-    advancedDeviceLibImplementation("com.fingerprint.android:pro:2.3.0") {
+    advancedDeviceLibImplementation("com.fingerprint.android:pro:2.3.2") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
     }
 

--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 
     reactNativeImplementation("com.facebook.react:react-native:0.71.0-rc.0")
 
-    advancedDeviceLibImplementation("com.fingerprint.android:pro:2.3.2") {
+    advancedDeviceLibImplementation("com.fingerprint.android:pro:2.3.0") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
     }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.runBlocking
 
 class NeuroID
     private constructor(
-        internal val application: Application?,
+        internal var application: Application?,
         internal var clientKey: String,
         serverEnvironment: String = "production"
     ) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -53,7 +53,7 @@ class NeuroID
     private constructor(
         internal var application: Application?,
         internal var clientKey: String,
-        serverEnvironment: String = "production"
+        serverEnvironment: String = PRODUCTION
     ) {
         @Volatile internal var pauseCollectionJob: Job? = null // internal only for testing purposes
         private val ioDispatcher: CoroutineScope = CoroutineScope(Dispatchers.IO)
@@ -92,13 +92,13 @@ class NeuroID
 
         init {
             when (serverEnvironment) {
-                "production" -> {
-                    endpoint = "${Constants.productionEndpoint.displayName}"
-                    scriptEndpoint = "${Constants.productionScriptsEndpoint.displayName}"
-                }
-                "development" -> {
+                DEVELOPMENT -> {
                     endpoint = "${Constants.devEndpoint.displayName}"
                     scriptEndpoint = "${Constants.devScriptsEndpoint.displayName}"
+                }
+                else -> {
+                    endpoint = "${Constants.productionEndpoint.displayName}"
+                    scriptEndpoint = "${Constants.productionScriptsEndpoint.displayName}"
                 }
             }
 
@@ -187,11 +187,14 @@ class NeuroID
 
         data class Builder(val application: Application? = null,
                            val clientKey: String = "",
-                           val serverEnvironment: String= "prod") {
+                           val serverEnvironment: String = PRODUCTION) {
             fun build() = NeuroID(application, clientKey, serverEnvironment)
         }
 
         companion object {
+            const val PRODUCTION = "production"
+            const val DEVELOPMENT = "development"
+
             var showLogs: Boolean = true
             var isSDKStarted = false
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
@@ -9,7 +9,7 @@ enum class Constants(val displayName: String) {
     debugEventTag("Event"),
     fpjsProdDomain("https://advanced.neuro-id.com"),
     productionEndpoint("https://receiver.neuroid.cloud/"),
-    productionScriptsEndpoint("http://scripts.neuro-id.com/"),
+    productionScriptsEndpoint("https://scripts.neuro-id.com/"),
     devEndpoint("https://receiver.neuro-dev.com/"),
-    devScriptsEndpoint("http://scripts.neuro-dev.com/")
+    devScriptsEndpoint("https://scripts.neuro-dev.com/")
 } 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -67,7 +67,7 @@ open class NeuroIDClassUnitTests {
     // Helper Functions
     private fun setNeuroIDInstance() {
         val neuroId = NeuroID.Builder(
-            null, "key_test_fake1234"
+            null, "key_test_fake1234", NeuroID.DEVELOPMENT
         ).build()
         NeuroID.setNeuroIDInstance(neuroId)
     }

--- a/app/src/main/java/com/sample/neuroid/us/MyApplicationDemo.kt
+++ b/app/src/main/java/com/sample/neuroid/us/MyApplicationDemo.kt
@@ -31,9 +31,11 @@ class MyApplicationDemo : MultiDexApplication() {
                 .penaltyLog()
                 .build()
         )
+        // tied to form id: form_dream102
         val neuroID = NeuroID.Builder(
             this,
-            "key_live_suj4CX90v0un2k1ufGrbItT5"
+            "key_live_suj4CX90v0un2k1ufGrbItT5",
+            "development"
         ).build()
         NeuroID.setNeuroIDInstance(neuroID)
         NeuroID.getInstance()?.setEnvironmentProduction(true)

--- a/app/src/main/java/com/sample/neuroid/us/MyApplicationDemo.kt
+++ b/app/src/main/java/com/sample/neuroid/us/MyApplicationDemo.kt
@@ -35,7 +35,7 @@ class MyApplicationDemo : MultiDexApplication() {
         val neuroID = NeuroID.Builder(
             this,
             "key_live_suj4CX90v0un2k1ufGrbItT5",
-            "development"
+            NeuroID.DEVELOPMENT
         ).build()
         NeuroID.setNeuroIDInstance(neuroID)
         NeuroID.getInstance()?.setEnvironmentProduction(true)


### PR DESCRIPTION
There is a bug in our test code where the setTestURL is not running on initialize when the NeuroID instance is built. This fix ensures that the proper environment is set before the remote config is pulled during unit test run. Setting the config in @Before in the integration test is too late. The remoteConfig is already pulled. The remote config is pulled on init() in NeuroID right after the constructor. 

Our customers will not need to  make changes to their code because the production environment is set as default. 