### PR TITLE
ENG-7738 move channel instance creation before starting service

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt
@@ -35,13 +35,13 @@ internal class NIDJobServiceManager(
     internal var clientKey = ""
     internal var isSetup: Boolean = false
 
-    private var sendEventsJob: Job = createSendEventsServer()
     internal var sendCadenceJob: Job? = null
     internal var gyroCadenceJob: Job? = null
 
     private val sendEventsNotification = Channel<Boolean>(Channel.UNLIMITED)
     private var application: Application? = null
     private var activityManager: ActivityManager? = null
+    private var sendEventsJob: Job = createSendEventsServer()
 
     @Synchronized
     fun startJob(


### PR DESCRIPTION
Move channel creation before starting the job service. This allows the startService to have an instance of Channel to call methods on. 

java.lang.NullPointerException: Attempt to invoke interface method 'kotlinx.coroutines.channels.ChannelIterator kotlinx.coroutines.channels.Channel.iterator()' on a null object reference
