### PR TITLE
ENG 7735 login attempt tracking

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -329,7 +329,7 @@ class NeuroID
                 if (validateUserId(attemptedRegisteredUserId)) {
                     captureEvent(
                         type = ATTEMPTED_LOGIN,
-                        uid = attemptedRegisteredUserId.hashCode().toString()
+                        uid = attemptedRegisteredUserId
                     )
                     return true
                 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -832,6 +832,7 @@ class NeuroID
         internal fun captureEvent(
             queuedEvent: Boolean = false,
             type: String,
+            // had to change to Calendar for tests. Cannot mock System methods.
             ts: Long = Calendar.getInstance().timeInMillis,
             attrs: List<Map<String, Any>>? = null,
             tg: Map<String, Any>? = null,

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.Calendar
 
 class NeuroID
     private constructor(
@@ -321,6 +322,20 @@ class NeuroID
 
             this.registeredUserID = registeredUserId
             return true
+        }
+
+        override fun attemptedLogin(attemptedRegisteredUserId: String?): Boolean {
+            attemptedRegisteredUserId?.let {
+                if (validateUserId(attemptedRegisteredUserId)) {
+                    captureEvent(
+                        type = ATTEMPTED_LOGIN,
+                        uid = attemptedRegisteredUserId.hashCode().toString()
+                    )
+                    return true
+                }
+            }
+            captureEvent(type=ATTEMPTED_LOGIN, uid="scrubbed-id-failed-validation")
+            return false
         }
 
         override fun setUserID(userID: String): Boolean {
@@ -817,7 +832,7 @@ class NeuroID
         internal fun captureEvent(
             queuedEvent: Boolean = false,
             type: String,
-            ts: Long = System.currentTimeMillis(),
+            ts: Long = Calendar.getInstance().timeInMillis,
             attrs: List<Map<String, Any>>? = null,
             tg: Map<String, Any>? = null,
             tgs: String? = null,

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -325,17 +325,19 @@ class NeuroID
         }
 
         override fun attemptedLogin(attemptedRegisteredUserId: String?): Boolean {
-            attemptedRegisteredUserId?.let {
-                if (validateUserId(attemptedRegisteredUserId)) {
-                    captureEvent(
-                        type = ATTEMPTED_LOGIN,
-                        uid = attemptedRegisteredUserId
-                    )
-                    return true
+            try {
+                attemptedRegisteredUserId?.let {
+                    if (validateUserId(attemptedRegisteredUserId)) {
+                        captureEvent(type = ATTEMPTED_LOGIN, uid = attemptedRegisteredUserId)
+                        return true
+                    }
                 }
+                captureEvent(type = ATTEMPTED_LOGIN, uid = "scrubbed-id-failed-validation")
+                return true
+            } catch (exception: Exception) {
+                logger.e(msg = "exception in attemptedLogin() ${exception.message}")
+                return false
             }
-            captureEvent(type=ATTEMPTED_LOGIN, uid="scrubbed-id-failed-validation")
-            return false
         }
 
         override fun setUserID(userID: String): Boolean {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroIDPublic.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroIDPublic.kt
@@ -189,8 +189,8 @@ interface NeuroIDPublic {
     fun startSession(sessionID: String? = null): SessionStartResult
 
     /**
-     * This should be called when the user attempts to login. Returns true if a passed in
-     * attemptedRegisteredUserId is valid otherwise returns false.
+     * This should be called when the user attempts to login. Returns true always. Returns false if
+     * exception is thrown during the process.
      */
     fun attemptedLogin(attemptedRegisteredUserId: String? = null): Boolean
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroIDPublic.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroIDPublic.kt
@@ -187,4 +187,10 @@ interface NeuroIDPublic {
      * indicating the started state of the SDK.
      */
     fun startSession(sessionID: String? = null): SessionStartResult
+
+    /**
+     * This should be called when the user attempts to login. Returns true if a passed in
+     * attemptedRegisteredUserId is valid otherwise returns false.
+     */
+    fun attemptedLogin(attemptedRegisteredUserId: String? = null): Boolean
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/events/NIDConstants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/events/NIDConstants.kt
@@ -65,6 +65,7 @@ const val CADENCE_READING_ACCEL = "CADENCE_READING_ACCEL"
 const val LOW_MEMORY = "LOW_MEMORY"
 const val FULL_BUFFER = "FULL_BUFFER"
 const val OUT_OF_MEMORY = "OUT_OF_MEMORY"
+const val ATTEMPTED_LOGIN = "ATTEMPTED_LOGIN"
 
 // NID origin codes
 const val NID_ORIGIN_NID_SET = "nid"

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -3,6 +3,7 @@ package com.neuroid.tracker.models
 import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.events.ADVANCED_DEVICE_REQUEST
 import com.neuroid.tracker.events.APPLICATION_SUBMIT
+import com.neuroid.tracker.events.ATTEMPTED_LOGIN
 import com.neuroid.tracker.events.BLUR
 import com.neuroid.tracker.events.CLOSE_SESSION
 import com.neuroid.tracker.events.CONTEXT_MENU
@@ -228,6 +229,7 @@ data class NIDEventModel(
                 ADVANCED_DEVICE_REQUEST -> contextString = "rid=${this.rid}, c=${this.c}"
                 LOG -> contextString = "m=${this.m}, ts=${this.ts}, level=${this.level}"
                 NETWORK_STATE -> contextString = "iswifi=${this.isWifi}, isconnected=${this.isConnected}"
+                ATTEMPTED_LOGIN -> contextString = "uid=${this.uid}"
                 else -> {}
             }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -259,21 +259,21 @@ open class NeuroIDClassUnitTests {
         NeuroID.isSDKStarted = true
     }
 
-    private fun testAttemptedLogin(userId: String?, expectedHash: String, expectedResult: Boolean) {
+    private fun testAttemptedLogin(userId: String?, expectedUserId: String, expectedResult: Boolean) {
         setupAttemptedLoginTestEnvironment()
         val dataStoreManager = NeuroID.getInternalInstance()?.dataStore
         val actualResult = NeuroID.getInstance()?.attemptedLogin(userId)
-        verify {dataStoreManager?.saveEvent(NIDEventModel(ts=1, type="ATTEMPTED_LOGIN", uid="$expectedHash"))}
+        verify {dataStoreManager?.saveEvent(NIDEventModel(ts=1, type="ATTEMPTED_LOGIN", uid="$expectedUserId"))}
         assertEquals(expectedResult, actualResult)
         unmockkStatic(Calendar::class)
     }
 
-    private fun testAttemptedLoginException(userId: String?, expectedHash: String, expectedResult: Boolean) {
+    private fun testAttemptedLoginException(userId: String?, expectedUserId: String, expectedResult: Boolean) {
         setupAttemptedLoginTestEnvironmentException()
         val dataStoreManager = NeuroID.getInternalInstance()?.dataStore
         val logger = NeuroID.getInternalInstance()?.logger
         val actualResult = NeuroID.getInstance()?.attemptedLogin(userId)
-        verify {dataStoreManager?.saveEvent(NIDEventModel(ts=1, type="ATTEMPTED_LOGIN", uid="$expectedHash"))}
+        verify {dataStoreManager?.saveEvent(NIDEventModel(ts=1, type="ATTEMPTED_LOGIN", uid="$expectedUserId"))}
         verify {logger?.e(any(), msg = "exception in attemptedLogin() save event exception")}
         assertEquals(expectedResult, actualResult)
         unmockkStatic(Calendar::class)

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -254,7 +254,7 @@ open class NeuroIDClassUnitTests {
     fun testAttemptedLoginVarious() {
         setupAttemptedLoginTestEnvironment()
         // the single good id
-        testAttemptedLogin("goodone", "207034505", true)
+        testAttemptedLogin("goodone", "goodone", true)
         // all the rest are rubbish ids
         testAttemptedLogin("12", "scrubbed-id-failed-validation", false)
         testAttemptedLogin("test@test.com'", "scrubbed-id-failed-validation", false)

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -228,12 +228,15 @@ open class NeuroIDClassUnitTests {
     //   setTestURL
 
     private fun setupAttemptedLoginTestEnvironment() {
+        // fake out the clock
         mockkStatic(Calendar::class)
         every {Calendar.getInstance().timeInMillis} returns 1
-        setMockedDataStore()
+        // make the logger not throw
         val logger = mockk<NIDLogWrapper>()
         every { logger.e(any(), any()) } just runs
         NeuroID.getInternalInstance()?.logger = logger
+        // everything else as normal
+        setMockedDataStore()
         setMockedNIDJobServiceManager(false)
         NeuroID.isSDKStarted = true
     }
@@ -241,9 +244,9 @@ open class NeuroIDClassUnitTests {
     private fun testAttemptedLogin(userId: String?, expectedHash: String, expectedResult: Boolean) {
         setupAttemptedLoginTestEnvironment()
         val dataStoreManager = NeuroID.getInternalInstance()?.dataStore
-        val result = NeuroID.getInstance()?.attemptedLogin(userId)
+        val actualResult = NeuroID.getInstance()?.attemptedLogin(userId)
         verify {dataStoreManager?.saveEvent(NIDEventModel(ts=1, type="ATTEMPTED_LOGIN", uid="$expectedHash"))}
-        assertEquals(expectedResult, result)
+        assertEquals(expectedResult, actualResult)
         unmockkStatic(Calendar::class)
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -252,7 +252,6 @@ open class NeuroIDClassUnitTests {
 
     @Test
     fun testAttemptedLoginVarious() {
-        setupAttemptedLoginTestEnvironment()
         // the single good id
         testAttemptedLogin("goodone", "goodone", true)
         // all the rest are rubbish ids


### PR DESCRIPTION
When a user attempts a login, send an attempted login event. The ATTEMPTED_LOGIN event JSON is shown below when `NeuroID.attemptedLogin()` is called. 

```
 {
      "accel": {
        "x": 1.4117653,
        "y": 7.8197446,
        "z": 6.9116683
      },
      "gyro": {
        "x": 0.11193776,
        "y": -0.4395046,
        "z": -0.03191677
      },
      "ts": 1713937081132,
      "type": "ATTEMPTED_LOGIN",
      "uid": "891896486"
},
```