### PR TITLE
ENG-7840-adding adv libs to release

### DIFF
--- a/.github/workflows/github-actions-master-push-assamble.yml
+++ b/.github/workflows/github-actions-master-push-assamble.yml
@@ -31,9 +31,10 @@ jobs:
           fetch-tags: true
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
 
       - name: Cache Gradle and wrapper
         uses: actions/cache@v2

--- a/.github/workflows/github-actions-push-assamble.yml
+++ b/.github/workflows/github-actions-push-assamble.yml
@@ -25,9 +25,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
 
       - name: Cache Gradle and wrapper
         uses: actions/cache@v2

--- a/.github/workflows/github-actions-tag-assamble.yml
+++ b/.github/workflows/github-actions-tag-assamble.yml
@@ -22,9 +22,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
 
       - name: Cache Gradle and wrapper
         uses: actions/cache@v2

--- a/.github/workflows/github-actions-tag-assamble.yml
+++ b/.github/workflows/github-actions-tag-assamble.yml
@@ -57,7 +57,11 @@ jobs:
           NeuroID/build/outputs/aar/androidLib/neuro-id-android-sdk-androidLib-${{ env.GITHUB_SDK_VERSION}}-release.aar#neuro-id-android-sdk-androidLib-${{ env.GITHUB_SDK_VERSION}}-release  \
           NeuroID/build/outputs/aar/reactNativeLib/neuro-id-android-sdk-reactNativeLib-${{ env.GITHUB_SDK_VERSION}}-release.aar#neuro-id-android-sdk-reactNativeLib-${{ env.GITHUB_SDK_VERSION}}-release \
           NeuroID/build/outputs/aar/androidLib/neuro-id-android-sdk-androidLib-${{ env.GITHUB_SDK_VERSION}}-debug.aar#neuro-id-android-sdk-androidLib-${{ env.GITHUB_SDK_VERSION}}-debug  \
-          NeuroID/build/outputs/aar/reactNativeLib/neuro-id-android-sdk-reactNativeLib-${{ env.GITHUB_SDK_VERSION}}-debug.aar#neuro-id-android-sdk-reactNativeLib-${{ env.GITHUB_SDK_VERSION}}-debug \
+          NeuroID/build/outputs/aar/reactNativeLib/neuro-id-android-sdk-reactNativeLib-${{ env.GITHUB_SDK_VERSION}}-debug.aar#neuro-id-android-sdk-reactNativeLib-${{ env.GITHUB_SDK_VERSION}}-debug \    
+          NeuroID/build/outputs/aar/androidAdvancedDeviceLib/neuro-id-android-sdk-androidAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-release.aar#neuro-id-android-sdk-androidAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-release  \
+          NeuroID/build/outputs/aar/reactNativeAdvancedDeviceLib/neuro-id-android-sdk-reactNativeAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-release.aar#neuro-id-android-sdk-reactNativeAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-release \
+          NeuroID/build/outputs/aar/androidAdvancedDeviceLib/neuro-id-android-sdk-androidAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-debug.aar#neuro-id-android-sdk-androidAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-debug  \
+          NeuroID/build/outputs/aar/reactNativeAdvancedDeviceLib/neuro-id-android-sdk-reactNativeAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-debug.aar#neuro-id-android-sdk-reactNativeAdvancedDeviceLib-${{ env.GITHUB_SDK_VERSION}}-debug \
           --generate-notes --title "${{ env.TAG_NAME }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   buildAllFlavors:
     name: Build All Flavors
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout
@@ -27,7 +27,7 @@ jobs:
 
   build:
     name: Build AAR
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout
@@ -43,7 +43,7 @@ jobs:
 
   test:
     name: SDK Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-
+          distribution: 'temurin'
       - name: Build All Flavors ⚙️🛠
         run: bash testBuildFlavors.sh
 
@@ -34,10 +34,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-
+          distribution: 'temurin'
       - name: Build AAR ⚙️🛠
         run: bash ./gradlew :NeuroID:assemble
 
@@ -50,9 +50,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
 
       # Execute unit test neuroid lib
       - name: Unit Test NeuroId


### PR DESCRIPTION
Adding advanced Native Android and RN libs to the assets released. 
Changed unit test runner to ubuntu-latest since there were errors running the emulator action `ReactiveCircus/android-emulator-runner@v2` on mac os.  