### PR TITLE
ENG-7873 move LocationService out of NIDMetaData

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -112,7 +112,6 @@ class NeuroID
                 locationService = LocationService()
                 metaData = NIDMetaData(
                     it.applicationContext,
-                    locationService
                 )
 
                 nidJobServiceManager =
@@ -611,7 +610,7 @@ class NeuroID
             application?.let {
                 val sharedDefaults = NIDSharedPrefsDefaults(it)
                 // get updated GPS location if possible
-                metaData?.getLastKnownLocation(it, nidSDKConfig.geoLocation)
+                metaData?.getLastKnownLocation(it, nidSDKConfig.geoLocation, locationService)
                 captureEvent(
                     type = MOBILE_METADATA_ANDROID,
                     sw = NIDSharedPrefsDefaults.getDisplayWidth().toFloat(),

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject
 
 import com.neuroid.tracker.service.LocationService
 
-class NIDMetaData(context: Context, private val locationService: LocationService?) {
+class NIDMetaData(context: Context) {
     private val brand = Build.BRAND
     private var device = Build.DEVICE
     private var display = Build.DISPLAY
@@ -89,7 +89,7 @@ class NIDMetaData(context: Context, private val locationService: LocationService
         }
     }
 
-    internal fun getLastKnownLocation(context: Context, isLocationAllowed: Boolean) {
+    internal fun getLastKnownLocation(context: Context, isLocationAllowed: Boolean, locationService: LocationService?) {
         locationService?.getLastKnownLocation(context, gpsCoordinates,
             locationManager=context.getSystemService(Context.LOCATION_SERVICE) as LocationManager,
             isLocationAllowed=isLocationAllowed)


### PR DESCRIPTION
Moved the LocationService out of NIDMetaData by moving the instance of LocationService out of the NIDMetaData from the constructor and instead passing in the LocationService dependency into getLastKnownLocation() directly. When the NIDMetaData is serialized by Gson.toJson(), the LocationService class info will not be serialized and the serialization call will not fail with the stack overflow error as seen earlier.  First launch data packet request not containing the LocationService class info is below: 

```
{
  "siteId": "",
  "userId": "fghdhd",
  "clientId": "f0b920b6-13aa-4be5-ae32-7649af542c10",
  "identityId": "fghdhd",
  "registeredUserId": "",
  "pageTag": "com.neuroid.example.PersonalInformation",
  "pageId": "mobile",
  "tabId": "mobile",
  "responseId": "98917b2e-ca58-4adf-b7cb-bc97005f62a1",
  "url": "android://com.neuroid.example.PersonalInformation",
  "jsVersion": "5.0.0",
  "sdkVersion": "5.android-3.2.1",
  "environment": "LIVE",
  "jsonEvents": [
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "isConnected": true,
      "isWifi": true,
      "ts": 1715033501685,
      "type": "NETWORK_STATE"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "key": "sessionIdCode",
      "ts": 1715033512487,
      "type": "SET_VARIABLE",
      "v": "201"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "key": "sessionIdSource",
      "ts": 1715033512487,
      "type": "SET_VARIABLE",
      "v": "customer"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "key": "sessionId",
      "ts": 1715033512487,
      "type": "SET_VARIABLE",
      "v": "fghdhd"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "ts": 1715033512488,
      "type": "SET_USER_ID",
      "uid": "fghdhd"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "ce": true,
      "cid": "f0b920b6-13aa-4be5-ae32-7649af542c10",
      "did": "1715011715653.1.8027861874769874E9",
      "dnt": false,
      "f": "key_live_3K92Tq4hxJPzCoq1VJ8Dr7vl",
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "iid": "1715011715654.1.6542631071829853E9",
      "je": true,
      "jsl": [],
      "jsv": "5.android-3.2.1",
      "lng": "en",
      "loc": "en_US",
      "lsid": "null",
      "metadata": {
        "batteryLevel": 97,
        "brand": "google",
        "carrier": "",
        "device": "sunfish",
        "display": "TQ3A.230805.001.S1",
        "displayResolution": "1080,2138",
        "gpsCoordinates": {
          "authorizationStatus": "authorized",
          "latitude": 37.301532,
          "longitude": -122.0484589
        },
        "isJailBreak": false,
        "isSimulator": false,
        "isWifiOn": true,
        "manufacturer": "Google",
        "model": "Pixel 4a",
        "osVersion": "33",
        "product": "sunfish",
        "totalMemory": 5.462299346923828
      },
      "ns": "nid",
      "ol": true,
      "p": "Android",
      "sh": 2138.0,
      "sid": "e32fa661-f36e-41dd-9599-7c1105e14488",
      "sw": 1080.0,
      "ts": 1715033512522,
      "type": "CREATE_SESSION",
      "tzo": 300,
      "ua": "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 4a Build/TQ3A.230805.001.S1)",
      "url": "android://com.neuroid.example.Splash"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "c": true,
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "rid": "1715011716626.dROJXJ",
      "ts": 1715033512536,
      "type": "ADVANCED_DEVICE_REQUEST"
    },
    {
      "accel": {
        "x": -0.12562318,
        "y": 7.6163545,
        "z": 6.1710896
      },
      "attrs": [
        {
          "isRN": false
        }
      ],
      "ce": true,
      "cid": "f0b920b6-13aa-4be5-ae32-7649af542c10",
      "did": "1715011715653.1.8027861874769874E9",
      "dnt": false,
      "f": "key_live_3K92Tq4hxJPzCoq1VJ8Dr7vl",
      "gyro": {
        "x": -0.008399149,
        "y": -6.1084726E-4,
        "z": -0.004428643
      },
      "iid": "1715011715654.1.6542631071829853E9",
      "je": true,
      "jsl": [],
      "jsv": "5.android-3.2.1",
      "lng": "en",
      "loc": "en_US",
      "lsid": "null",
      "metadata": {
        "batteryLevel": 97,
        "brand": "google",
        "carrier": "",
        "device": "sunfish",
        "display": "TQ3A.230805.001.S1",
        "displayResolution": "1080,2138",
        "gpsCoordinates": {
          "authorizationStatus": "authorized",
          "latitude": 37.301532,
          "longitude": -122.0484589
        },
        "isJailBreak": false,
        "isSimulator": false,
        "isWifiOn": true,
        "manufacturer": "Google",
        "model": "Pixel 4a",
        "osVersion": "33",
        "product": "sunfish",
        "totalMemory": 5.462299346923828
      },
      "ns": "nid",
      "ol": true,
      "p": "Android",
      "sh": 2138.0,
      "sid": "e32fa661-f36e-41dd-9599-7c1105e14488",
      "sw": 1080.0,
      "ts": 1715033512541,
      "type": "MOBILE_METADATA_ANDROID",
      "tzo": 300,
      "ua": "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 4a Build/TQ3A.230805.001.S1)",
      "url": ""
    },
    {
      "accel": {
        "x": -0.2727818,
        "y": 6.9344,
        "z": 6.7501526
      },
      "attrs": [
        {
          "component": "activity",
          "lifecycle": "paused",
          "className": "com.neuroid.example.Instructions"
        }
      ],
      "gyro": {
        "x": 0.036498122,
        "y": -0.0219905,
        "z": 0.045966256
      },
      "ts": 1715033512587,
      "type": "WINDOW_BLUR"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "isRN": false
        }
      ],
      "ce": true,
      "cid": "f0b920b6-13aa-4be5-ae32-7649af542c10",
      "did": "1715011715653.1.8027861874769874E9",
      "dnt": false,
      "f": "key_live_3K92Tq4hxJPzCoq1VJ8Dr7vl",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "iid": "1715011715654.1.6542631071829853E9",
      "je": true,
      "jsl": [],
      "jsv": "5.android-3.2.1",
      "lng": "en",
      "loc": "en_US",
      "lsid": "null",
      "metadata": {
        "batteryLevel": 97,
        "brand": "google",
        "carrier": "",
        "device": "sunfish",
        "display": "TQ3A.230805.001.S1",
        "displayResolution": "1080,2138",
        "gpsCoordinates": {
          "authorizationStatus": "authorized",
          "latitude": 37.301532,
          "longitude": -122.0484589
        },
        "isJailBreak": false,
        "isSimulator": false,
        "isWifiOn": true,
        "manufacturer": "Google",
        "model": "Pixel 4a",
        "osVersion": "33",
        "product": "sunfish",
        "totalMemory": 5.462299346923828
      },
      "ns": "nid",
      "ol": true,
      "p": "Android",
      "sh": 2138.0,
      "sid": "e32fa661-f36e-41dd-9599-7c1105e14488",
      "sw": 1080.0,
      "ts": 1715033512620,
      "type": "MOBILE_METADATA_ANDROID",
      "tzo": 300,
      "ua": "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 4a Build/TQ3A.230805.001.S1)",
      "url": ""
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "component": "activity",
          "lifecycle": "postCreated",
          "className": "com.neuroid.example.PersonalInformation"
        }
      ],
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "ts": 1715033512803,
      "type": "WINDOW_LOAD"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "component": "activity",
          "lifecycle": "resumed",
          "className": "com.neuroid.example.PersonalInformation"
        }
      ],
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "ts": 1715033512807,
      "type": "WINDOW_FOCUS"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "firstname",
      "en": "firstname",
      "et": "Edittext::TextInputEditText",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "firstname",
      "ts": 1715033512815,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/firstname",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "lastname",
      "en": "lastname",
      "et": "Edittext::TextInputEditText",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "lastname",
      "ts": 1715033512822,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/lastname",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "dateofbirth",
      "en": "dateofbirth",
      "et": "Edittext::TextInputEditText",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "dateofbirth",
      "ts": 1715033512828,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/dateofbirth",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {
          "type": "radioButton",
          "id": "radio_red",
          "rGroupId": "color_group"
        }
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "radio_red",
      "en": "radio_red",
      "et": "RadioButton::MaterialRadioButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "07dc39a1",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {
            "type": "radioButton",
            "id": "radio_red",
            "rGroupId": "color_group"
          }
        ]
      },
      "tgs": "radio_red",
      "ts": 1715033512834,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/radio_red",
      "v": "false"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {
          "type": "radioButton",
          "id": "radio_blue",
          "rGroupId": "color_group"
        }
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "radio_blue",
      "en": "radio_blue",
      "et": "RadioButton::MaterialRadioButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "07dc39a1",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {
            "type": "radioButton",
            "id": "radio_blue",
            "rGroupId": "color_group"
          }
        ]
      },
      "tgs": "radio_blue",
      "ts": 1715033512840,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/radio_blue",
      "v": "false"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {
          "type": "radioButton",
          "id": "radio_green",
          "rGroupId": "color_group"
        }
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "radio_green",
      "en": "radio_green",
      "et": "RadioButton::MaterialRadioButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "07dc39a1",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {
            "type": "radioButton",
            "id": "radio_green",
            "rGroupId": "color_group"
          }
        ]
      },
      "tgs": "radio_green",
      "ts": 1715033512847,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/radio_green",
      "v": "false"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {
          "type": "radioButton",
          "id": "radio_red",
          "rGroupId": "color_group"
        }
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "radio_red",
      "en": "radio_red",
      "et": "RadioButton::MaterialRadioButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "07dc39a1",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {
            "type": "radioButton",
            "id": "radio_red",
            "rGroupId": "color_group"
          }
        ]
      },
      "tgs": "radio_red",
      "ts": 1715033512853,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/radio_red",
      "v": "false"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {
          "type": "radioButton",
          "id": "radio_blue",
          "rGroupId": "color_group"
        }
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "radio_blue",
      "en": "radio_blue",
      "et": "RadioButton::MaterialRadioButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "07dc39a1",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {
            "type": "radioButton",
            "id": "radio_blue",
            "rGroupId": "color_group"
          }
        ]
      },
      "tgs": "radio_blue",
      "ts": 1715033512859,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/radio_blue",
      "v": "false"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {
          "type": "radioButton",
          "id": "radio_green",
          "rGroupId": "color_group"
        }
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "radio_green",
      "en": "radio_green",
      "et": "RadioButton::MaterialRadioButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "07dc39a1",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "RadioGroup/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {
            "type": "radioButton",
            "id": "radio_green",
            "rGroupId": "color_group"
          }
        ]
      },
      "tgs": "radio_green",
      "ts": 1715033512865,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/radio_green",
      "v": "false"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "color_group",
      "en": "color_group",
      "et": "RadioGroup::RadioGroup",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "3ab1640e",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "color_group",
      "ts": 1715033512871,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/color_group",
      "v": "-1"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "home",
      "en": "home",
      "et": "Button::MaterialButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "home",
      "ts": 1715033512877,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/home",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "next",
      "en": "next",
      "et": "Button::MaterialButton",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "next",
      "ts": 1715033512882,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/next",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "checkBox3",
      "en": "checkBox3",
      "et": "CheckBox::MaterialCheckBox",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "checkBox3",
      "ts": 1715033512889,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/checkBox3",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "checkBox4",
      "en": "checkBox4",
      "et": "CheckBox::MaterialCheckBox",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "checkBox4",
      "ts": 1715033512894,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/checkBox4",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "attrs": [
        {
          "n": "guid",
          "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
        },
        {
          "n": "screenHierarchy",
          "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
        },
        {
          "parentClass": "com.neuroid.example.PersonalInformation",
          "component": "activity"
        },
        {}
      ],
      "ec": "com.neuroid.example.PersonalInformation",
      "eid": "checkBox_other",
      "en": "checkBox_other",
      "et": "CheckBox::MaterialCheckBox",
      "etn": "INPUT",
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64098f81",
      "tg": {
        "attr": [
          {
            "n": "guid",
            "v": "2c5035ad-9664-3f85-be38-8ae95d75bbbc"
          },
          {
            "n": "screenHierarchy",
            "v": "ConstraintLayout/com.neuroid.example.PersonalInformation"
          },
          {
            "parentClass": "com.neuroid.example.PersonalInformation",
            "component": "activity"
          },
          {}
        ]
      },
      "tgs": "checkBox_other",
      "ts": 1715033512900,
      "type": "REGISTER_TARGET",
      "url": "android://com.neuroid.example.PersonalInformation/checkBox_other",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64afe9d6",
      "tg": {
        "attr": [
          {
            "n": "v",
            "v": "S~C~~0"
          },
          {
            "n": "hash",
            "v": "64afe9d6"
          }
        ],
        "etn": "INPUT",
        "et": "text"
      },
      "tgs": "firstname",
      "ts": 1715033512920,
      "type": "INPUT",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64afe9d6",
      "tg": {
        "attr": [
          {
            "n": "v",
            "v": "S~C~~0"
          },
          {
            "n": "hash",
            "v": "64afe9d6"
          }
        ],
        "etn": "INPUT",
        "et": "text"
      },
      "tgs": "lastname",
      "ts": 1715033512938,
      "type": "INPUT",
      "v": "S~C~~0"
    },
    {
      "accel": {
        "x": -0.23389842,
        "y": 6.9619174,
        "z": 6.6562343
      },
      "gyro": {
        "x": 0.057572354,
        "y": -0.0047340663,
        "z": 0.0581832
      },
      "hv": "64afe9d6",
      "tg": {
        "attr": [
          {
            "n": "v",
            "v": "S~C~~0"
          },
          {
            "n": "hash",
            "v": "64afe9d6"
          }
        ],
        "etn": "INPUT",
        "et": "text"
      },
      "tgs": "dateofbirth",
      "ts": 1715033512956,
      "type": "INPUT",
      "v": "S~C~~0"
    }
  ]
}
```
