### PR TITLE
ENG-6428 update network info on startup

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.IntentFilter
 import android.location.LocationManager
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.neuroid.tracker.callbacks.ActivityCallbacks
@@ -90,7 +92,7 @@ class NeuroID
         internal var lowMemory: Boolean = false
         internal var isConnected = false
         internal var locationService: LocationService? = null
-        internal var isWifi = false
+        internal var networkConnectionType = "unknown"
 
         init {
             when (serverEnvironment) {
@@ -162,8 +164,41 @@ class NeuroID
                 if (isConnectingOrConnected != null) {
                     isConnected = isConnectingOrConnected
                 }
-                isWifi = info?.type == ConnectivityManager.TYPE_WIFI
+                networkConnectionType = this.getNetworkType(it)
             }
+        }
+
+        /**
+         * Function to retrieve the current network type (wifi, cell, eth, unknown)
+         */
+        internal fun getNetworkType(context: Context): String {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val activeNetwork = connectivityManager.activeNetwork
+                activeNetwork?.let {
+                    val networkCapabilities = connectivityManager.getNetworkCapabilities(it)
+                    networkCapabilities?.let { capabilities ->
+                        return when {
+                            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "wifi"
+                            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "cell"
+                            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "eth"
+                            else -> "unknown"
+                        }
+                    }
+                }
+            } else {
+                // For devices below API level 23
+                val activeNetworkInfo = connectivityManager.activeNetworkInfo
+                activeNetworkInfo?.let {
+                    return when (it.type) {
+                        ConnectivityManager.TYPE_WIFI -> "wifi"
+                        ConnectivityManager.TYPE_MOBILE -> "cell"
+                        ConnectivityManager.TYPE_ETHERNET -> "eth"
+                        else -> "unknown"
+                    }
+                }
+            }
+            return "noNetwork"
         }
 
         private fun setRemoteConfig() = runBlocking {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -90,6 +90,7 @@ class NeuroID
         internal var lowMemory: Boolean = false
         internal var isConnected = false
         internal var locationService: LocationService? = null
+        internal var isWifi = false
 
         init {
             when (serverEnvironment) {
@@ -150,6 +151,18 @@ class NeuroID
                 nidCallActivityListener = NIDCallActivityListener(dataStore, VersionChecker())
                 this.getApplicationContext()
                     ?.let { nidCallActivityListener?.setCallActivityListener(it) }
+            }
+
+            //get connectivity info on startup
+            application?.let {
+                val connectivityManager =
+                    it.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                val info = connectivityManager.activeNetworkInfo
+                val isConnectingOrConnected = info?.isConnectedOrConnecting()
+                if (isConnectingOrConnected != null) {
+                    isConnected = isConnectingOrConnected
+                }
+                isWifi = info?.type == ConnectivityManager.TYPE_WIFI
             }
         }
 


### PR DESCRIPTION
This was not done in the previous Network service PR (ENG-6428). ENG-7716 (FPJS latency reporting) needs this to send back FPJS latency data (connection type) if the app just started and the network config did not change.

ENG-7716 (FPJS latency reporting) is based on this branch. 