### PR TITLE
ENG-8167 api 21 crash fix

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/LocationService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/LocationService.kt
@@ -2,11 +2,11 @@ package com.neuroid.tracker.service
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
+import androidx.core.location.LocationListenerCompat
 import com.neuroid.tracker.models.NIDLocation
 import com.neuroid.tracker.utils.LocationPermissionUtils
 import com.neuroid.tracker.utils.NIDMetaData
@@ -29,12 +29,11 @@ class LocationService(private val locationPermissionUtils: LocationPermissionUti
     private var locationScope: CoroutineScope? = null
 
     @SuppressLint("MissingPermission")
-    private val locationListener =
-        LocationListener { location ->
-            nidLocation?.longitude = location.longitude
-            nidLocation?.latitude = location.latitude
-            nidLocation?.authorizationStatus = NIDMetaData.LOCATION_AUTHORIZED_ALWAYS
-        }
+    private val locationListener = LocationListenerCompat { location ->
+        nidLocation?.longitude = location.longitude
+        nidLocation?.latitude = location.latitude
+        nidLocation?.authorizationStatus = NIDMetaData.LOCATION_AUTHORIZED_ALWAYS
+    }
 
     /**
      * this will setup a new coroutine for use in requestLocation(). requestLocation() requries a


### PR DESCRIPTION
On API 21 devices, the location service will try to invoke the onStatusChanged() method in the LocationListener. The onStatusChanged() was deprecated in API 29 and not invoked in devices at or above API29 however in testing on an API21 device, it is invoked cause the exception show below: 

`java.lang.AbstractMethodError: abstract method "void android.location.LocationListener.onStatusChanged(java.lang.String, int, android.os.Bundle)"`

To fix this we use the LocationListenerCompat which will avoid the need to implement the onStatusChanged() method for all API version down to 21. The docs specify this below: 
 
https://developer.android.com/reference/android/location/LocationListener

```Note that this method only has a default implementation on Android R and above, and this method must still be overridden in order to run successfully on Android versions below R. LocationListenerCompat from the compat libraries may be used to avoid the need to override for older platforms.```