### PR TITLE
ENG-8175 check if started and exit start() if so. fix unit tests

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
@@ -87,7 +87,7 @@ internal class NIDSessionService(
         siteID: String?,
         completion: (Boolean) -> Unit = {},
     ) {
-        if (!validationService.verifyClientKeyExists(neuroID.clientKey)) {
+        if (NeuroID.isSDKStarted || !validationService.verifyClientKeyExists(neuroID.clientKey)) {
             completion(false)
             return
         }

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
@@ -23,6 +23,7 @@ import com.neuroid.tracker.models.SessionStartResult
 import com.neuroid.tracker.storage.NIDDataStoreManager
 import com.neuroid.tracker.verifyCaptureEvent
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
@@ -72,6 +73,12 @@ class NIDSessionServiceTest {
             )
 
         val mockedConfigService = getMockedConfigService()
+
+        // we need to mock these two to create listeners in the test,
+        // these are set to false by default
+        every {mockedConfigService.configCache.geoLocation} returns true
+        every {mockedConfigService.configCache.callInProgress} returns true
+
         val mockedSampleService =
             getMockSampleService(
                 0L,
@@ -567,9 +574,15 @@ class NIDSessionServiceTest {
 
         every { mockedNeuroID.pauseCollectionJob } returns null
 
+        // need to mock config and return true for location service since this is now
+        // set false by default
+        val mockedConfigService = mockk<NIDConfigService>()
+        every {mockedConfigService.configCache.geoLocation} returns true
+
         val sessionService =
             createSessionServiceInstance(
-                mockedNeuroID,
+                configService = mockedConfigService,
+                mockedNeuroID = mockedNeuroID,
             )
 
         sessionService.resumeCollection()
@@ -608,9 +621,15 @@ class NIDSessionServiceTest {
                 isCompleted = false,
             )
 
+        // need to mock config and return true for location service since this is now
+        // set false by default
+        val mockedConfigService = mockk<NIDConfigService>()
+        every {mockedConfigService.configCache.geoLocation} returns true
+
         val sessionService =
             createSessionServiceInstance(
-                mockedNeuroID,
+                configService = mockedConfigService,
+                mockedNeuroID = mockedNeuroID,
             )
 
         sessionService.resumeCollection()

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
@@ -1179,6 +1179,36 @@ class NIDSessionServiceTest {
         }
     }
 
+    @Test
+    fun testStartWhileSDKIsStarted() {
+        val mockedServices = buildMockClasses()
+        val mockedJobServiceManager = mockedServices.mockedJobServiceManager
+        val mockedValidationService = mockedServices.mockedValidationService
+        val mockedNeuroID = mockedServices.mockedNeuroID
+
+        NeuroID._isSDKStarted = true
+
+        every {
+            mockedValidationService.verifyClientKeyExists(any())
+        } returns true
+
+        val sessionService =
+            createSessionServiceInstance(
+                mockedNeuroID,
+                validationService = mockedValidationService,
+            )
+
+        sessionService.start(
+            siteID = testSiteID
+        ) {
+            assert(!it)
+
+            verify(exactly = 0) {
+                mockedJobServiceManager.startJob(any(), any())
+            }
+        }
+    }
+
     private fun validateStartAppFlowTest(
         flowResult: SessionStartResult,
         siteID: String,


### PR DESCRIPTION
Check if the SDK is already started(). If so, exit immediately. This will stop the starting of multiple data manager queues that might be occurring right now if start() is called twice in a row without stopping. 