### PR TITLE
Eng 7894 dont call fpjs if session not sampled

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
@@ -76,7 +76,9 @@ internal class NIDSessionService(
             NIDSingletonIDs.retrieveOrCreateLocalSalt()
 
             neuroID.dataStore.saveAndClearAllQueuedEvents()
-            neuroID.checkThenCaptureAdvancedDevice()
+            if (samplingService.isSessionFlowSampled()) {
+                neuroID.checkThenCaptureAdvancedDevice()
+            }
 
             completion()
         }
@@ -270,7 +272,9 @@ internal class NIDSessionService(
 
                 createSession()
 
-                neuroID.checkThenCaptureAdvancedDevice()
+                if (samplingService.isSessionFlowSampled()) {
+                    neuroID.checkThenCaptureAdvancedDevice()
+                }
 
                 neuroID.addLinkedSiteID(siteID)
                 completion(

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
@@ -1068,7 +1068,6 @@ class NIDSessionServiceTest {
     fun test_startAppFlow_start_noUID() {
         val mockedServices = buildMockClasses()
         val mockedSampleService = mockedServices.mockedSampleService
-        every {mockedSampleService.isSessionFlowSampled()} returns true
         val mockedValidationService = mockedServices.mockedValidationService
         val mockedJobServiceManager = mockedServices.mockedJobServiceManager
 


### PR DESCRIPTION
Missed these checks to ensure that we don't capture the advanced device id when we are not sampling events. 