### PR TITLE
ENG-8301 prefix "nid-" to the generated user ids.

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/UtilExt.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/UtilExt.kt
@@ -10,5 +10,5 @@ fun Activity.getGUID(): String {
 
 internal fun generateUniqueHexID(): String {
     // use random UUID to ensure uniqueness amongst devices,
-    return UUID.randomUUID().toString()
+    return "nid-${UUID.randomUUID()}"
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
@@ -27,7 +27,7 @@ class NeuroIdUnitTest {
 
         every { uuid.toString() } returns "test"
         val temp = generateUniqueHexID()
-        assertEquals(temp, "test")
+        assertEquals(temp, "nid-test")
 
         unmockkAll()
     }


### PR DESCRIPTION
generated user ids will now include a "mid-" prefixed to them. 