### PR TITLE
ENG-8306-low-memory-check-test

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -25,7 +25,7 @@ data class NIDRemoteConfig(
     @SerializedName(value = "site_id")
     val siteID: String = "",
     @SerializedName(value = "low_memory_back_off")
-    val lowMemoryBackOff: Int = 3,
+    val lowMemoryBackOff: Int = 5,
     @SerializedName(value = "low_memory_threshold")
-    val lowMemoryThreshold: Double = 0.15,
+    val lowMemoryThreshold: Double = 0.25,
 )

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -27,5 +27,5 @@ data class NIDRemoteConfig(
     @SerializedName(value = "low_memory_back_off")
     val lowMemoryBackOff: Int = 3,
     @SerializedName(value = "low_memory_threshold")
-    val lowMemoryThreshold: Int = 1000000000
+    val lowMemoryThreshold: Double = 0.15,
 )

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -24,4 +24,8 @@ data class NIDRemoteConfig(
     val sampleRate: Int = NIDConfigService.DEFAULT_SAMPLE_RATE,
     @SerializedName(value = "site_id")
     val siteID: String = "",
+    @SerializedName(value = "low_memory_back_off")
+    val lowMemoryBackOff: Int = 3,
+    @SerializedName(value = "low_memory_threshold")
+    val lowMemoryThreshold: Int = 1000000000
 )

--- a/app/src/debug/java/com/sample/neuroid/us/activities/MainActivity.kt
+++ b/app/src/debug/java/com/sample/neuroid/us/activities/MainActivity.kt
@@ -99,6 +99,9 @@ class MainActivity : AppCompatActivity() {
         var isRunning = false
         var job: Job? = null
 
+        /**
+         * Stop consuming memory and release consumed memory for the GC to collect.
+         */
         fun stopEating(){
             job?.let {
                 it.cancel()
@@ -108,21 +111,22 @@ class MainActivity : AppCompatActivity() {
                 println("createResetLowMemoryWatchdogServer canceling eater")
             }
         }
+
+        /**
+         * Consume memory till the allocated memory (total) equals the max allocated memory (max).
+         * Eats in ~400KB chunks.
+         */
         fun eat() {
             isRunning = true
             println("createResetLowMemoryWatchdogServer starting eater")
             job = CoroutineScope(Dispatchers.IO).launch {
-                while(isRunning) {
+                while(isRunning && Runtime.getRuntime().maxMemory() != Runtime.getRuntime().totalMemory()) {
                     val stringBuffer = StringBuffer()
                     for(i in 0..100000) {
                         stringBuffer.append("h453")
                     }
                     buffer.add(stringBuffer.toString())
-                    val mi = ActivityManager.MemoryInfo()
-                    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-                    activityManager.getMemoryInfo(mi)
-                    println("eater: total: ${mi.totalMem} avail: ${mi.availMem} threshold: ${mi.threshold} islow: ${mi.lowMemory}")
-                    println("eater: free ${Runtime.getRuntime().freeMemory()} max: ${Runtime.getRuntime().maxMemory()} total: ${Runtime.getRuntime().totalMemory()}")
+                    println("eater: max ${Runtime.getRuntime().maxMemory()} free: ${Runtime.getRuntime().freeMemory()} total: ${Runtime.getRuntime().totalMemory()}")
                     delay(500L)
                 }
             }

--- a/app/src/debug/res/layout/nid_activity_main.xml
+++ b/app/src/debug/res/layout/nid_activity_main.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:id="@+id/layout_main"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -136,6 +136,22 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="10dp"
                 android:text="Close session"
+                android:textAllCaps="false" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/stop_mem_eater"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:text="stop_mem_eater"
+                android:textAllCaps="false" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/start_mem_eater"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:text="start_mem_eater"
                 android:textAllCaps="false" />
 
         </LinearLayout>

--- a/app/src/main/java/com/sample/neuroid/us/MyApplicationDemo.kt
+++ b/app/src/main/java/com/sample/neuroid/us/MyApplicationDemo.kt
@@ -36,7 +36,7 @@ class MyApplicationDemo : MultiDexApplication() {
         // NeuroID.getInstance()?.start()
         // NeuroID.getInstance()?.setEnvironmentProduction(true)
         // NeuroID.getInstance()?.setSiteId(configHelper.formId)
-        NeuroID.getInstance()?.startAppFlow("form_parks912", null)
+        NeuroID.getInstance()?.startAppFlow("form_parks911", "zero123")
         // NeuroID.getInstance()?.startAppFlow("form_skein469", "testSession")
         // NeuroID.getInstance()?.startSession("hasdklghs")
         // NeuroID.getInstance()?.setUserID("fgdsgasdgsdg")


### PR DESCRIPTION
Draft PR to test the new low memory watchdog. Will remove the sample app changes and debug after testing is complete. 

Use the sample app's memory eater function (start and stop buttons in the sample app) to consume memory and stop the eater when the total and max memory are the same (look in the logs to see this). Then play with the app to send events (tap around, enter text in text fields to trigger events). If the free memory is < 100MB, the SDK will be put into low memory mode by the watchdog and you should only see low memory events being sent to server (use the application network inspector to see this). The SDK will remain in low memory mode for a short period of time. The garbage collector will eventually start up and return the memory that was consumed. The low memory watchdog will set the low memory flag to false and the SDK will send events as normal (again check the logs). 

If you let the eater run after the max and total memory are equal, this will trigger an out of memory exception and crash the app. 

We need to figure out the proper default parameters for the watchdog delay and the proper memory size that triggers low memory mode. 

[https://neuro-id.atlassian.net/browse/ENG-8306](https://neuro-id.atlassian.net/browse/ENG-8306) has more details. 