### PR TITLE
ENG-8375 - Update Screen Hierarchy Logic

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/events/RegistrationIdentificationHelper.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/events/RegistrationIdentificationHelper.kt
@@ -18,7 +18,8 @@ import com.neuroid.tracker.callbacks.NIDGlobalEventCallback
 import com.neuroid.tracker.callbacks.NIDLongPressContextMenuCallbacks
 import com.neuroid.tracker.callbacks.NIDTextContextMenuCallbacks
 import com.neuroid.tracker.extensions.getIdOrTag
-import com.neuroid.tracker.extensions.getParents
+import com.neuroid.tracker.extensions.getParentActivity
+import com.neuroid.tracker.extensions.getParentFragment
 import com.neuroid.tracker.extensions.getSHA256withSalt
 import com.neuroid.tracker.utils.NIDLogWrapper
 import com.neuroid.tracker.utils.NIDTextWatcher
@@ -342,6 +343,7 @@ class SingleTargetListenerRegister(
             createAtrrList(
                 view,
                 guid,
+                idName,
                 activityOrFragment,
                 parent,
             )
@@ -401,6 +403,7 @@ class SingleTargetListenerRegister(
     fun createAtrrList(
         view: View,
         guid: String,
+        idName: String,
         activityOrFragment: String = "",
         parent: String = "",
     ): MutableList<Map<String, Any>> {
@@ -410,22 +413,39 @@ class SingleTargetListenerRegister(
                 "v" to guid,
             )
 
-        val classJson =
+        val parentActivity = view.getParentActivity()
+        val parentFragment = view.getParentFragment()
+
+        val screenHierarchy =
             mapOf<String, Any>(
                 "n" to "screenHierarchy",
-                "v" to "${view.getParents(logger)}${NeuroID.screenName}",
+                "v" to "/$parentActivity/${parentFragment ?: ""}$idName",
             )
 
-        val parentData =
+        val topScreenHierarchy =
             mapOf<String, Any>(
-                "parentClass" to parent,
-                "component" to activityOrFragment,
+                "n" to "top-screenHierarchy",
+                "v" to "/$parent/$idName",
+            )
+
+        val parentClassData =
+            mapOf<String, Any>(
+                "n" to "parentClass",
+                "v" to parent,
+            )
+
+        val parentComponentData =
+            mapOf<String, Any>(
+                "n" to "component",
+                "v" to activityOrFragment,
             )
 
         return mutableListOf(
             idJson,
-            classJson,
-            parentData,
+            screenHierarchy,
+            topScreenHierarchy,
+            parentClassData,
+            parentComponentData,
         )
     }
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt
@@ -1,7 +1,12 @@
 package com.neuroid.tracker.extensions
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.content.res.Resources
 import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.neuroid.tracker.utils.NIDLogWrapper
 
 fun View?.getIdOrTag(): String {
@@ -54,4 +59,69 @@ fun View.getParentsOfView(
         log.e(msg = "instance ${view.parent?.javaClass?.name} is not a view!")
         "not_a_view"
     }
+}
+
+fun View.getParentActivity(): String? {
+    var context: Context? = this.context
+    while (context is Context) {
+        if (context is Activity) {
+            return context::class.java.name
+        }
+        if (context is ContextWrapper) {
+            context = context.baseContext
+        } else {
+            return null
+        }
+    }
+    return null
+}
+
+fun View.getParentFragment(): String? {
+    var context = this.context
+    while (context is ContextWrapper) {
+        if (context is FragmentActivity) {
+            val fragments = (context as FragmentActivity).supportFragmentManager.fragments
+            for (fragment in fragments) {
+                val foundFragment = findFragment(this, fragment)
+                if (foundFragment != null) {
+                    val result = buildFragAncestry(foundFragment).reversed().joinToString(separator = "/")
+                    return "$result/"
+                }
+            }
+        }
+        context = context.baseContext
+    }
+    return null
+}
+
+private fun findFragment(
+    view: View,
+    fragment: Fragment?,
+): Fragment? {
+    if (fragment == null || fragment.view == null) {
+        return null
+    }
+    if (view == fragment.view || view.parent == fragment.view) {
+        return fragment
+    }
+
+    val childFragments = fragment.childFragmentManager.fragments
+    for (childFragment in childFragments) {
+        val foundFragment = findFragment(view, childFragment)
+        if (foundFragment != null) {
+            return foundFragment
+        }
+    }
+    return null
+}
+
+private fun buildFragAncestry(fragment: Fragment): List<String> {
+    return mutableListOf<String>(
+        fragment::class.java.name,
+    ) +
+        if (fragment.parentFragment != null) {
+            buildFragAncestry(fragment.requireParentFragment())
+        } else {
+            mutableListOf<String>()
+        }
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -215,7 +215,7 @@ data class NIDEventModel(
                 "CLICK" -> contextString = ""
                 REGISTER_TARGET ->
                     contextString =
-                        "et=${this.et}, rts=${this.rts}, ec=${this.ec} v=${this.v} tg=${this.tg} meta=${this.metadata}"
+                        "et=${this.et}, rts=${this.rts}, ec=${this.ec} v=${this.v} tg=${this.tg} meta=${this.metadata} attrs=[${this.attrs}]"
                 "DEREGISTER_TARGET" -> contextString = ""
                 TOUCH_START -> contextString = "xy=${this.touches} tg=${this.tg}"
                 TOUCH_END -> contextString = "xy=${this.touches} tg=${this.tg}"

--- a/NeuroID/src/test/java/com/neuroid/tracker/AndroidTestUtils.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AndroidTestUtils.kt
@@ -7,6 +7,8 @@ import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.location.LocationManager
+import android.view.View
+import android.view.ViewGroup
 import com.neuroid.tracker.events.RegistrationIdentificationHelper
 import com.neuroid.tracker.models.NIDRemoteConfig
 import com.neuroid.tracker.models.NIDResponseCallBack
@@ -423,6 +425,17 @@ internal fun getMockedJob(
     every { mockedJob.invokeOnCompletion(any()) } returns mockk<DisposableHandle>()
 
     return mockedJob
+}
+
+internal fun getMockedView(child: View): View {
+    val view = mockk<ViewGroup>()
+    val mockedContext = mockk<Context>()
+    every { view.childCount } returns 1
+    every { view.getChildAt(0) } returns child
+    every { view.contentDescription } returns "view group"
+    every { view.context } returns mockedContext
+
+    return view
 }
 
 internal fun verifyCaptureEvent(

--- a/NeuroID/src/test/java/com/neuroid/tracker/events/NIDIdentityAllViewsTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/events/NIDIdentityAllViewsTest.kt
@@ -1,7 +1,6 @@
 package com.neuroid.tracker.events
 
 import android.text.Editable
-import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.RadioButton
@@ -10,7 +9,8 @@ import android.widget.RatingBar
 import android.widget.SeekBar
 import android.widget.ToggleButton
 import androidx.appcompat.widget.SwitchCompat
-import com.neuroid.tracker.NeuroID
+import com.neuroid.tracker.getMockedNeuroID
+import com.neuroid.tracker.getMockedView
 import com.neuroid.tracker.utils.NIDLogWrapper
 import io.mockk.every
 import io.mockk.just
@@ -22,16 +22,16 @@ import org.junit.Test
 class NIDIdentityAllViewsTest {
     @Test
     fun identifyAllViews_edit_text() {
-        val view = mockk<ViewGroup>()
         val editText = mockk<EditText>()
         val editTextEditable = mockk<Editable>()
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns editText
-        every { view.contentDescription } returns "view group"
+        val view = getMockedView(editText)
+
+        every { editTextEditable.length } returns "this is edit text1 text".length
+
+        every { editText.context } returns view.context
         every { editText.contentDescription } returns "edit text 1"
         every { editText.text } returns editTextEditable
         every { editText.parent } returns null
-        every { editTextEditable.length } returns "this is edit text1 text".length
         every { editText.addTextChangedListener(any()) } just runs
         every { editText.getCustomSelectionActionModeCallback() } returns null
         every { editText.setCustomSelectionActionModeCallback(any()) } just runs
@@ -39,7 +39,7 @@ class NIDIdentityAllViewsTest {
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -53,18 +53,18 @@ class NIDIdentityAllViewsTest {
 
     @Test
     fun identifyAllViews_ToggleButton() {
-        val view = mockk<ViewGroup>()
         val toggleButton = mockk<ToggleButton>()
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns toggleButton
-        every { view.contentDescription } returns "view group"
+        val view = getMockedView(toggleButton)
+
+        every { toggleButton.context } returns view.context
         every { toggleButton.contentDescription } returns "toggle button 1"
         every { toggleButton.parent } returns null
+
         val logger = mockk<NIDLogWrapper>()
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -78,18 +78,18 @@ class NIDIdentityAllViewsTest {
 
     @Test
     fun identifyAllViews_SwitchCompat() {
-        val view = mockk<ViewGroup>()
         val switchCompat = mockk<SwitchCompat>()
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns switchCompat
-        every { view.contentDescription } returns "view group"
+        val view = getMockedView(switchCompat)
+
+        every { switchCompat.context } returns view.context
         every { switchCompat.contentDescription } returns "switch compat"
         every { switchCompat.parent } returns null
+
         val logger = mockk<NIDLogWrapper>()
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -103,18 +103,18 @@ class NIDIdentityAllViewsTest {
 
     @Test
     fun identifyAllViews_ImageButton() {
-        val view = mockk<ViewGroup>()
         val imageButton = mockk<ImageButton>()
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns imageButton
-        every { view.contentDescription } returns "view group"
+        val view = getMockedView(imageButton)
+
+        every { imageButton.context } returns view.context
         every { imageButton.contentDescription } returns "image button"
         every { imageButton.parent } returns null
+
         val logger = mockk<NIDLogWrapper>()
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -128,18 +128,18 @@ class NIDIdentityAllViewsTest {
 
     @Test
     fun identifyAllViews_SeekBar() {
-        val view = mockk<ViewGroup>()
         val seekBar = mockk<SeekBar>()
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns seekBar
-        every { view.contentDescription } returns "view group"
+        val view = getMockedView(seekBar)
+
+        every { seekBar.context } returns view.context
         every { seekBar.contentDescription } returns "seek bar"
         every { seekBar.parent } returns null
+
         val logger = mockk<NIDLogWrapper>()
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -148,18 +148,18 @@ class NIDIdentityAllViewsTest {
 
     @Test
     fun identifyAllViews_RatingBar() {
-        val view = mockk<ViewGroup>()
         val ratingBar = mockk<RatingBar>()
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns ratingBar
-        every { view.contentDescription } returns "view group"
+        val view = getMockedView(ratingBar)
+
+        every { ratingBar.context } returns view.context
         every { ratingBar.contentDescription } returns "rating bar"
         every { ratingBar.parent } returns null
+
         val logger = mockk<NIDLogWrapper>()
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -179,7 +179,10 @@ class NIDIdentityAllViewsTest {
         val radioButtonViewParent = mockk<RadioGroup>()
         val radioButton = mockk<RadioButton>()
         val radioGroup = mockk<RadioGroup>()
-        val view = mockk<ViewGroup>()
+        val view = getMockedView(radioGroup)
+
+        every { radioButton.context } returns view.context
+
         every { radioButtonViewParent4.id } returns 13
         every { radioButtonViewParent3.parent } returns radioButtonViewParent4
         every { radioButtonViewParent3.id } returns 12
@@ -188,9 +191,8 @@ class NIDIdentityAllViewsTest {
         every { radioButtonViewParent.parent } returns null
         every { radioButtonViewParent.contentDescription } returns "RadioGroupParent"
         every { radioButtonViewParent.id } returns 10
-        every { view.contentDescription } returns "viewgroup"
-        every { view.childCount } returns 1
-        every { view.getChildAt(0) } returns radioGroup
+
+        every { radioGroup.context } returns view.context
         every { radioGroup.parent } returns null
         every { radioGroup.setOnHierarchyChangeListener(any()) } just runs
         every { radioGroup.checkedRadioButtonId } returns 12
@@ -200,11 +202,12 @@ class NIDIdentityAllViewsTest {
         every { radioButton.contentDescription } returns "RadioButton"
         every { radioButton.isChecked } returns true
         every { radioButton.parent } returns radioButtonViewParent
+
         val logger = mockk<NIDLogWrapper>()
         every { logger.d(any(), any()) } just runs
         every { logger.e(any(), any()) } just runs
 
-        val nidMock = mockNeuroID()
+        val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
@@ -215,70 +218,5 @@ class NIDIdentityAllViewsTest {
                 "etn: INPUT, et: RadioButton, eid: RadioButton, v:true",
             )
         }
-    }
-
-    private fun mockNeuroID(): NeuroID {
-        val nidMock = mockk<NeuroID>()
-        every {
-            nidMock.captureEvent(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            )
-        } just runs
-
-        return nidMock
     }
 }


### PR DESCRIPTION
Element is registered from the `MyFragment` callback, but now the screen hierarchy shows where the element truly is from (I.e. `childFragment`)

Updated Event Example
```
EVENT: REGISTER_TARGET - childFrag1Email - 
et=Edittext::AppCompatEditText,
 rts=null, 
ec=AppInit 
v=S~C~~0
 tg={
   attr=[
       {n=guid, v=27f312bd-5d77-354a-b7ed-ec059a07ff9e}, 

// THIS IS THE IMPORTANT PIECE
       {n=screenHierarchy, v=/com.neuroid.example.Login/com.neuroid.example.MyFragment/com.neuroid.example.ChildFragment1/childFrag1Email}


       {n=top-screenHierarchy, v=/MyFragment/childFrag1Email},
        {n=parentClass, v=MyFragment}
      ,{n=component, v=fragment}, {}]}
```