### PR TITLE
ENG-8454 only add "nid-" prefix to session id

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
@@ -132,7 +132,7 @@ internal class NIDSessionService(
             stopSession()
         }
 
-        var finalSessionID = sessionID ?: generateUniqueHexID()
+        var finalSessionID = sessionID ?: generateUniqueHexID(true)
         if (!identifierService.setUserID(finalSessionID, sessionID != null)) {
             completion(SessionStartResult(false, ""))
             return

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/UtilExt.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/UtilExt.kt
@@ -8,7 +8,11 @@ fun Activity.getGUID(): String {
     return UUID.nameUUIDFromBytes(hashCodeAct.toString().toByteArray()).toString()
 }
 
-internal fun generateUniqueHexID(): String {
+internal fun generateUniqueHexID(requireNIDPrefix: Boolean = false): String {
     // use random UUID to ensure uniqueness amongst devices,
-    return "nid-${UUID.randomUUID()}"
+    var nidPrefix = ""
+    if (requireNIDPrefix) {
+        nidPrefix = "nid-"
+    }
+    return "$nidPrefix${UUID.randomUUID()}"
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
@@ -27,7 +27,10 @@ class NeuroIdUnitTest {
 
         every { uuid.toString() } returns "test"
         val temp = generateUniqueHexID()
-        assertEquals(temp, "nid-test")
+        assertEquals(temp, "test")
+
+        val temp2 = generateUniqueHexID(true)
+        assertEquals(temp2, "nid-test")
 
         unmockkAll()
     }


### PR DESCRIPTION
add "nid-" prefix to session id only. All other ids should not have the "nid-" prefix added. 

 "key": "sessionId",
      "ts": 1723502601357,
      "type": "SET_VARIABLE",
      "v": "\u0027nid-00cf0f71-0de3-404f-a2c9-7cb44fdc7811\u0027"



