### PR TITLE
ENG-8497 mitigate crash when MutableList.last() is called when empty

### DIFF
--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.7.10"
 
-    reactNativeImplementation("com.facebook.react:react-native:0.71.0-rc.0")
+    reactNativeImplementation("com.facebook.react:react-android:0.71.0-rc.0")
 
     advancedDeviceLibImplementation("com.fingerprint.android:pro:2.3.2") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'

--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.7.10"
 
-    reactNativeImplementation("com.facebook.react:react-android:0.71.0-rc.0")
+    reactNativeImplementation("com.facebook.react:react-android:0.71.0-rc.1")
 
     advancedDeviceLibImplementation("com.fingerprint.android:pro:2.3.2") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/VersionChecker.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/VersionChecker.kt
@@ -29,7 +29,7 @@ fun getAppMetaData(context: Context): ApplicationMetaData? {
             versionName = packageInfo.versionName,
             versionNumber = versionCode,
             packageName = packageInfo.packageName,
-            applicationName = packageInfo.applicationInfo.name,
+            applicationName = packageInfo.applicationInfo.name?:"",
         )
     } catch (e: PackageManager.NameNotFoundException) {
         e.printStackTrace()

--- a/NeuroID/src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt
@@ -177,7 +177,7 @@ class NIDDataStoreManagerUnitTests {
         val raceConditionedEventList = mockk<MutableList<NIDEventModel>>()
         every {raceConditionedEventList.size} returns 0
         every {raceConditionedEventList.isEmpty()} returns false
-        every {raceConditionedEventList.last()} throws NoSuchElementException("list is empty!")
+        every {raceConditionedEventList.last()} throws NoSuchElementException("list is empty fool!")
         every {raceConditionedEventList.add(any())} returns true
         dataStore.eventsList = raceConditionedEventList
         assert(!dataStore.isFullBuffer())

--- a/NeuroID/src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt
@@ -7,9 +7,12 @@ import com.neuroid.tracker.models.NIDRemoteConfig
 import com.neuroid.tracker.service.ConfigService
 import com.neuroid.tracker.utils.NIDLogWrapper
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -148,4 +151,36 @@ class NIDDataStoreManagerUnitTests {
             val events = dataStore.getAllEvents()
             Assert.assertEquals(0, events.count())
         }
+
+    @Test
+    fun isFullBuffer() {
+        val dataStore = mockDataStore()
+        assert(!dataStore.isFullBuffer())
+    }
+
+    @Test
+    fun isFullBuffer_isFull() {
+        val dataStore = mockDataStore()
+        for (i in 0..5000) {
+            dataStore.saveEvent(NIDEventModel(INPUT))
+        }
+        assert(dataStore.isFullBuffer())
+    }
+
+    @Test
+    fun isFullBuffer_crashMitigation() {
+        val serviceConfig = mockk<ConfigService>()
+        every { serviceConfig.configCache } returns NIDRemoteConfig()
+        val logger = mockk<NIDLogWrapper>()
+        every {logger.d(any(), any())} just runs
+        val dataStore = NIDDataStoreManagerImp(logger, serviceConfig)
+        val raceConditionedEventList = mockk<MutableList<NIDEventModel>>()
+        every {raceConditionedEventList.size} returns 0
+        every {raceConditionedEventList.isEmpty()} returns false
+        every {raceConditionedEventList.last()} throws NoSuchElementException("list is empty!")
+        every {raceConditionedEventList.add(any())} returns true
+        dataStore.eventsList = raceConditionedEventList
+        assert(!dataStore.isFullBuffer())
+        verify{logger.d(any(), "possible emptying before calling eventsList.last() after empty check occurred list is empty fool!")}
+    }
 }


### PR DESCRIPTION
This PR is to mitigate a crash that MGI is currently seeing in our 3.3.2 SDK. it is only happening on the Samsung S22 device in QE testing however that might just be coincidental and could probably happen to all devices. 

What we think is happening is a race condition where the isFullBuffer() method will check if the event list is empty, then the job manager will context switch to clear the event list calling swapEvents() then context switch back to isFullBuffer() which will call eventList.last() to get the last type, see it is empty and throw the exception below that MGI QE is seeing. To mitigate this, we Synchronize the isFullBuffer() method so it will complete execution without being context switched and add a try/catch to catch the exception and handle it if it happens anyway to ensure that we don't fall into this situation. 

Unit tests include to make sure this behavior is occurring. 

```
Caused by java.util.NoSuchElementException: List is empty.
       at kotlin.collections.CollectionsKt___CollectionsKt.last(_Collections.kt:418)
       at com.neuroid.tracker.storage.NIDDataStoreManagerImp.isFullBuffer(NIDDataStoreManager.kt:157)
       at com.neuroid.tracker.NeuroID.captureEvent$NeuroID_androidAdvancedDeviceLibDebug(NeuroID.kt:886)
       at com.neuroid.tracker.NeuroID.captureEvent$NeuroID_androidAdvancedDeviceLibDebug$default(NeuroID.kt:812)
       at com.neuroid.tracker.NeuroID.addLinkedSiteID$NeuroID_androidAdvancedDeviceLibDebug(NeuroID.kt:786)
       at com.neuroid.tracker.service.NIDSessionService$startAppFlow$2.invoke(NIDSessionService.kt:302)
       at com.neuroid.tracker.service.NIDSessionService$startAppFlow$2.invoke(NIDSessionService.kt:294)
       at com.neuroid.tracker.service.NIDSessionService$clearSendOldFlowEvents$2.invokeSuspend(NIDSessionService.kt:411)
```