### PR TITLE
ENG-8564 remove extra set activity lifecycle callback

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -9,6 +9,7 @@ import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
+import android.util.Log
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.neuroid.tracker.callbacks.ActivityCallbacks
@@ -365,6 +366,13 @@ class NeuroID
                 if (singleton == null) {
                     singleton = neuroID
                     singleton?.setupCallbacks()
+                } else {
+                    Log.e("NeuroID", "NeuroID SDK should only be built once.")
+                    singleton?.captureEvent(
+                        type = LOG,
+                        m = "NeuroID SDK should only be built once.",
+                        level = "ERROR"
+                    )
                 }
             }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -319,7 +319,6 @@ class NeuroID
                         isAdvancedDevice,
                         serverEnvironment,
                     )
-                neuroID.setupCallbacks()
                 setNeuroIDInstance(neuroID)
             }
         }

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -9,7 +9,6 @@ import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
-import android.util.Log
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.neuroid.tracker.callbacks.ActivityCallbacks
@@ -362,12 +361,17 @@ class NeuroID
             internal var scriptEndpoint = Constants.productionScriptsEndpoint.displayName
             private var singleton: NeuroID? = null
 
+            @TestOnly
+            internal fun setSingletonNull() {
+                singleton = null
+            }
+
             internal fun setNeuroIDInstance(neuroID: NeuroID) {
                 if (singleton == null) {
                     singleton = neuroID
                     singleton?.setupCallbacks()
                 } else {
-                    Log.e("NeuroID", "NeuroID SDK should only be built once.")
+                    singleton?.logger?.e("NeuroID", "NeuroID SDK should only be built once.")
                     singleton?.captureEvent(
                         type = LOG,
                         m = "NeuroID SDK should only be built once.",

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -67,6 +67,9 @@ open class NeuroIDClassUnitTests {
 
     // Helper Functions
     private fun setNeuroIDInstance() {
+        // set NeuroID singleton to null, else the NeuroID already initialized error will occur and
+        // fail test when NeuroID is built.
+        NeuroID.setSingletonNull()
         NeuroID.Builder(null, "key_test_fake1234", false, NeuroID.DEVELOPMENT).build()
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
@@ -127,6 +127,10 @@ class NIDSessionServiceTest {
     // SETUP/TAKEDOWN
     @Before
     fun setUp() {
+        // set NeuroID singleton to null, else the NeuroID already initialized error will occur and
+        // fail test when NeuroID is built.
+        NeuroID.setSingletonNull()
+
         // setup instance and logging
         setNeuroIDInstance()
 


### PR DESCRIPTION
Remove extra set activity lifecycle callback, let the setNeuroIDInstance() handle it. 

There is bug that will allow setting the Activity lifecycle callback handler without setting the NeuroID instance to the singleton if builder is called more than once. This might be causing situations where EditText fields are not sending back input events to our server. The callback handler will have a handle to the new job manager to send back events which does not exist and will silently error out because of a check that will not set the new NeuroID instance to the singleton. This will happen only on multiple calls to Builder.build().