### PR TITLE
ENG-8767 fix call listener registration

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/events/NIDConstants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/events/NIDConstants.kt
@@ -79,8 +79,9 @@ const val ORIGIN_CODE_CUSTOMER = "201"
 
 // Telephony Manager Call State Values https://developer.android.com/reference/android/telephony/TelephonyManager#CALL_STATE_IDLE
 enum class CallInProgress(val event: String, val state: Int) {
-    ACTIVE("true", 2),
-    RINGING("", 1),
-    INACTIVE("false", 0),
+    ACTIVE("active", 2 ),
+    RINGING("ringing", 1),
+    INACTIVE("inactive", 0),
     UNAUTHORIZED("unauthorized", 99),
+    UNKNOWN("unknown", -1),
 }


### PR DESCRIPTION
 fix call listener registration to not register multiple times.

call example (ringing (inactive)-> pickup (active) -> hangup (inactive)

```
2024-10-03 17:58:14.188 29771-29771 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: CALL_IN_PROGRESS - null - cp=false, metadata=[{progress=ringing}]
2024-10-03 17:58:20.949 29771-29771 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: CALL_IN_PROGRESS - null - cp=active, metadata=[{progress=active}]
2024-10-03 17:58:25.255 29771-29771 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: CALL_IN_PROGRESS - null - cp=inactive, metadata=[{progress=hangup}]
```
test coming up. 