### PR TITLE
add version and group to publish command

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,4 +4,4 @@ before_install:
   - sdk use java 17.0.13-zulu
 install:
   # only build and publish NeuroID module
-  - ./gradlew :NeuroID:publishToMavenLocal
+  - ./gradlew -Pgroup=$GROUP -Pversion=$VERSION :NeuroID:publishToMavenLocal


### PR DESCRIPTION
Add version and group to publish command. These were in the previous jitpack builds and must be used to add the version and branch name to the published files. 