### PR TITLE
ENG-9331 add last app install time in metadata

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -31,7 +31,6 @@ import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.models.NIDSensorModel
 import com.neuroid.tracker.models.NIDTouchModel
 import com.neuroid.tracker.models.SessionStartResult
-import com.neuroid.tracker.service.AdvancedDeviceIDManagerService
 import com.neuroid.tracker.service.ConfigService
 import com.neuroid.tracker.service.LocationService
 import com.neuroid.tracker.service.NIDCallActivityListener
@@ -78,6 +77,8 @@ class NeuroID
         internal var clientID = ""
         internal var userID = ""
         internal var linkedSiteID: String? = null
+        internal var firstInstallTime: Long = -1
+        internal var lastUpdateTime: Long = -1
         internal var packetNumber: Int = 0
         internal var tabID: String
 
@@ -126,6 +127,13 @@ class NeuroID
             )
 
         init {
+            // get install and update time now
+            getApplicationContext()?.let {
+                // The time at which the app was first installed. Units are as per System.currentTimeMillis().
+                firstInstallTime = it.packageManager?.getPackageInfo(it.packageName, 0)?.firstInstallTime ?: -1
+                // The time at which the app was last updated. Units are as per System.currentTimeMillis().
+                lastUpdateTime = it.packageManager?.getPackageInfo(it.packageName, 0)?.lastUpdateTime ?: -1
+            }
             when (serverEnvironment) {
                 PRODSCRIPT_DEVCOLLECTION -> {
                     endpoint = Constants.devEndpoint.displayName
@@ -941,7 +949,7 @@ class NeuroID
                     isConnected,
                     cp,
                     l,
-                    synthetic,
+                    synthetic
                 )
 
             if (queuedEvent) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -77,8 +77,6 @@ class NeuroID
         internal var clientID = ""
         internal var userID = ""
         internal var linkedSiteID: String? = null
-        internal var firstInstallTime: Long = -1
-        internal var lastUpdateTime: Long = -1
         internal var packetNumber: Int = 0
         internal var tabID: String
 
@@ -127,13 +125,6 @@ class NeuroID
             )
 
         init {
-            // get install and update time now
-            getApplicationContext()?.let {
-                // The time at which the app was first installed. Units are as per System.currentTimeMillis().
-                firstInstallTime = it.packageManager?.getPackageInfo(it.packageName, 0)?.firstInstallTime ?: -1
-                // The time at which the app was last updated. Units are as per System.currentTimeMillis().
-                lastUpdateTime = it.packageManager?.getPackageInfo(it.packageName, 0)?.lastUpdateTime ?: -1
-            }
             when (serverEnvironment) {
                 PRODSCRIPT_DEVCOLLECTION -> {
                     endpoint = Constants.devEndpoint.displayName

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
@@ -106,6 +106,8 @@ class NIDEventSender(
             }
 
         val linkedSiteID: String? = NeuroID.getInternalInstance()?.linkedSiteID
+        val firstInstallTime: Long? = NeuroID.getInternalInstance()?.firstInstallTime
+        val lastUpdateTime: Long? = NeuroID.getInternalInstance()?.lastUpdateTime
         val tabID =
             if (NeuroID.getInternalInstance()?.tabID != null) {
                 NeuroID.getInternalInstance()?.tabID
@@ -132,6 +134,8 @@ class NIDEventSender(
                 "jsonEvents" to events,
                 "linkedSiteId" to linkedSiteID,
                 "packetNumber" to packetNumber,
+                "firstInstallTime" to firstInstallTime,
+                "lastUpdateTime" to lastUpdateTime
             )
 
         NIDLog.d(
@@ -148,6 +152,8 @@ class NIDEventSender(
                 SDK Version: ${jsonBody["sdkVersion"]}
                 Screen Name: ${NeuroID.screenName}
                 Event Count: ${events.size}
+                First Install Time: ${jsonBody["firstInstallTime"]}
+                Last Update Time: ${jsonBody["lastUpdateTime"]}
                 """.trimIndent(),
         )
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
@@ -106,8 +106,6 @@ class NIDEventSender(
             }
 
         val linkedSiteID: String? = NeuroID.getInternalInstance()?.linkedSiteID
-        val firstInstallTime: Long? = NeuroID.getInternalInstance()?.firstInstallTime
-        val lastUpdateTime: Long? = NeuroID.getInternalInstance()?.lastUpdateTime
         val tabID =
             if (NeuroID.getInternalInstance()?.tabID != null) {
                 NeuroID.getInternalInstance()?.tabID
@@ -133,9 +131,7 @@ class NIDEventSender(
                 "environment" to NeuroID.environment,
                 "jsonEvents" to events,
                 "linkedSiteId" to linkedSiteID,
-                "packetNumber" to packetNumber,
-                "firstInstallTime" to firstInstallTime,
-                "lastUpdateTime" to lastUpdateTime
+                "packetNumber" to packetNumber
             )
 
         NIDLog.d(
@@ -152,8 +148,6 @@ class NIDEventSender(
                 SDK Version: ${jsonBody["sdkVersion"]}
                 Screen Name: ${NeuroID.screenName}
                 Event Count: ${events.size}
-                First Install Time: ${jsonBody["firstInstallTime"]}
-                Last Update Time: ${jsonBody["lastUpdateTime"]}
                 """.trimIndent(),
         )
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt
@@ -30,7 +30,6 @@ class NIDMetaData(context: Context) {
     private val isSimulator: Boolean
     private val gpsCoordinates: NIDLocation = NIDLocation(-1.0, -1.0, LOCATION_UNKNOWN)
     private val lastInstallTime = context.packageManager?.getPackageInfo(context.packageName, 0)?.firstInstallTime ?: -1
-    private val lastUpdateTime = context.packageManager?.getPackageInfo(context.packageName, 0)?.lastUpdateTime ?: -1
 
     init {
         displayResolution = getScreenResolution(context)
@@ -121,7 +120,6 @@ class NIDMetaData(context: Context) {
         jsonObject.put("isSimulator", isSimulator)
         jsonObject.put("gpsCoordinates", gpsCoordinates.toJson())
         jsonObject.put("lastInstallTime", lastInstallTime)
-        jsonObject.put("lastUpdateTime", lastUpdateTime)
         return jsonObject
     }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt
@@ -29,6 +29,8 @@ class NIDMetaData(context: Context) {
     private var isWifiOn: Boolean?
     private val isSimulator: Boolean
     private val gpsCoordinates: NIDLocation = NIDLocation(-1.0, -1.0, LOCATION_UNKNOWN)
+    private val lastInstallTime = context.packageManager?.getPackageInfo(context.packageName, 0)?.firstInstallTime ?: -1
+    private val lastUpdateTime = context.packageManager?.getPackageInfo(context.packageName, 0)?.lastUpdateTime ?: -1
 
     init {
         displayResolution = getScreenResolution(context)
@@ -118,6 +120,8 @@ class NIDMetaData(context: Context) {
         jsonObject.put("isWifiOn", isWifiOn)
         jsonObject.put("isSimulator", isSimulator)
         jsonObject.put("gpsCoordinates", gpsCoordinates.toJson())
+        jsonObject.put("lastInstallTime", lastInstallTime)
+        jsonObject.put("lastUpdateTime", lastUpdateTime)
         return jsonObject
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,9 +91,6 @@ android {
         lib {
             dimension "adv"
         }
-        advancedDeviceLib {
-            dimension "adv"
-        }
     }
 
     buildFeatures {

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -60,9 +60,6 @@ android {
         lib {
             dimension "adv"
         }
-        advancedDeviceLib {
-            dimension "adv"
-        }
     }
 }
 


### PR DESCRIPTION
Add last app install time in metadata event. The change will look like this: 

```
 "metadata": {
        "batteryLevel": 99,
        "brand": "google",
        "carrier": "",
        "device": "sunfish",
        "display": "TQ3A.230805.001.S2",
        "displayResolution": "1080,2138",
        "gpsCoordinates": {
          "authorizationStatus": "unknown",
          "latitude": -1.0,
          "longitude": -1.0
        },
        "isJailBreak": false,
        "isSimulator": false,
        "isWifiOn": true,
        "lastInstallTime": 1740447749466,
        "manufacturer": "Google",
        "model": "Pixel 4a",
        "osVersion": "33",
        "product": "sunfish",
        "totalMemory": 5.472507476806641
      },
```
