### PR TITLE
ENG-9436 remove source jar from release builds (android and react native)

### DIFF
--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -142,6 +142,15 @@ dependencies {
 }
 
 afterEvaluate {
+    // remove the sources jar from the release version of the library
+    tasks.matching { t ->
+        t.name == 'androidLibReleaseSourcesJar'
+                || t.name == 'generateAndroidLibReleaseSources'
+                || t.name == 'reactNativeLibReleaseSourcesJar'
+                || t.name == 'generateReactNativeLibReleaseSourcesJar'
+    }.configureEach { t ->
+        t.enabled = false
+    }
     publishing {
         publications {
             // Creates a Maven publication called "release".


### PR DESCRIPTION
Remove source jar from release builds (Android SDK , ReactNative). The debug builds retain source. 

```
➜  ~ cd .m2/repository/com/neuroid/android-sdk
➜  android-sdk ls
"3.5.2"                  maven-metadata-local.xml
➜  android-sdk cd \"3.5.2\" 
➜  "3.5.2" ls
android-sdk-"3.5.2".aar    android-sdk-"3.5.2".module android-sdk-"3.5.2".pom

➜  "3.5.2" cd ..
➜  android-sdk ls
"3.5.2"                  maven-metadata-local.xml
➜  android-sdk cd ..
➜  neuroid ls
android-sdk             android-sdk-debug       react-android-sdk       react-android-sdk-debug
➜  neuroid cd react-android-sdk  
➜  react-android-sdk ls
"3.5.2"                  maven-metadata-local.xml
➜  react-android-sdk cd \"3.5.2\" 
➜  "3.5.2" ls
react-android-sdk-"3.5.2".aar    react-android-sdk-"3.5.2".module react-android-sdk-"3.5.2".pom

➜  "3.5.2" cd ..
➜  react-android-sdk ls
"3.5.2"                  maven-metadata-local.xml
➜  react-android-sdk cd ..
➜  neuroid ls
android-sdk             android-sdk-debug       react-android-sdk       react-android-sdk-debug
➜  neuroid cd android-sdk-debug 
➜  android-sdk-debug cd \"3.5.2\" 
➜  "3.5.2" ls
android-sdk-debug-"3.5.2"-sources.jar android-sdk-debug-"3.5.2".aar         android-sdk-debug-"3.5.2".module      android-sdk-debug-"3.5.2".pom

➜  "3.5.2" cd ..
➜  android-sdk-debug cd ..
➜  neuroid ls
android-sdk             android-sdk-debug       react-android-sdk       react-android-sdk-debug
➜  neuroid cd react-android-sdk-debug 
➜  react-android-sdk-debug cd \"3.5.2\" 
➜  "3.5.2" ls
react-android-sdk-debug-"3.5.2"-sources.jar react-android-sdk-debug-"3.5.2".module
react-android-sdk-debug-"3.5.2".aar         react-android-sdk-debug-"3.5.2".pom
➜  "3.5.2" 
```
