### PR TITLE
ENG-9437 obfuscate code, keep production logging

### DIFF
--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -52,7 +52,7 @@ android {
             buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField "String", "VERSION_NAME", "${defaultConfig.versionName}"
             buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
@@ -119,7 +119,7 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.lifecycle:lifecycle-process:2.4.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'

--- a/NeuroID/proguard-rules.pro
+++ b/NeuroID/proguard-rules.pro
@@ -28,3 +28,41 @@
     public static int e(...);
     public static int w(...);
 }
+
+#-keepattributes Signature
+-keepattributes *Annotation*
+
+-keep class com.google.gson.** { *; }
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.Expose <fields>;
+}
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.Since <fields>;
+}
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.Until <fields>;
+}
+
+# have to keep these
+-keepattributes LineNumberTable,SourceFile
+-renamesourcefileattribute SourceFile
+-keep class com.neuroid.tracker.models.** { *; }
+-keep class com.neuroid.tracker.events.** { *; }
+-keep class com.neuroid.tracker.NeuroIDPublic { *; }
+-keep class com.neuroid.tracker.NeuroID { *; }
+-keep class com.neuroid.tracker.compose.** { *; }
+-keep class com.neuroid.tracker.utils.** { *; }
+-keep class com.neuroid.tracker.NeuroID$Companion { *; }
+-keep class com.neuroid.tracker.NeuroID$Builder { *; }
+
+-keepclassmembers class com.neuroid.tracker.NeuroID$Companion {
+    public static com.neuroid.tracker.NeuroID getInstance();
+    public static com.neuroid.tracker.NeuroID builder();
+}

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -36,7 +36,7 @@ import com.neuroid.tracker.events.WINDOW_LOAD
 import com.neuroid.tracker.events.WINDOW_RESIZE
 import com.neuroid.tracker.events.WINDOW_UNLOAD
 import com.neuroid.tracker.utils.Constants
-import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.neuroid.tracker.utils.NIDMetaData
 import org.json.JSONArray
 import org.json.JSONObject
@@ -104,7 +104,9 @@ data class NIDEventModel(
     val cp: String? = null,
     val l: Long? = null,
     val synthetic: Boolean? = null,
+    val logger: NIDLogWrapper = NIDLogWrapper()
 ) : Comparable<NIDEventModel> {
+
     fun toJSONString(): String {
         return toJSON().toString()
     }
@@ -200,7 +202,7 @@ data class NIDEventModel(
     }
 
     internal fun log() {
-        NIDLog.d(Constants.debugEventTag.displayName, "") {
+        logger.d(tag=Constants.debugEventTag.displayName, msg="") {
             var contextString: String? = ""
             when (this.type) {
                 PAUSE_EVENT_CAPTURE -> contextString = ""

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDCallActivityListener.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDCallActivityListener.kt
@@ -21,7 +21,9 @@ import com.neuroid.tracker.utils.VersionChecker
 class NIDCallActivityListener(
     private val neuroID: NeuroID,
     private val versionChecker: VersionChecker,
+    private val logger: NIDLog = NIDLog()
 ) : BroadcastReceiver() {
+
     private lateinit var intentFilter: IntentFilter
     lateinit var intent: Intent
     private var isReceiverRegistered = false
@@ -51,11 +53,11 @@ class NIDCallActivityListener(
                 Manifest.permission.READ_PHONE_STATE,
             ) == PackageManager.PERMISSION_GRANTED && !isReceiverRegistered
         ) {
-            NIDLog.d(msg = "Initializing call activity listener")
+            logger.d(msg = "Initializing call activity listener")
             intentFilter = IntentFilter("android.intent.action.PHONE_STATE")
             context.registerReceiver(this, intentFilter)
         } else {
-            NIDLog.d(msg = "Permission to listen to call status not found")
+            logger.d(msg = "Permission to listen to call status not found")
             saveCallInProgressEvent(CallInProgress.UNAUTHORIZED.state)
         }
     }
@@ -75,7 +77,7 @@ class NIDCallActivityListener(
         when (state) {
             CallInProgress.INACTIVE.state -> {
                 callStateActive = false
-                NIDLog.d(msg = "Call inactive")
+                logger.d(msg = "Call inactive")
                 neuroID.captureEvent(
                     type = CALL_IN_PROGRESS,
                     cp = CallInProgress.INACTIVE.event,
@@ -84,7 +86,7 @@ class NIDCallActivityListener(
             }
             CallInProgress.ACTIVE.state -> {
                 callStateActive = true
-                NIDLog.d(msg = "Call in progress")
+                logger.d(msg = "Call in progress")
                 neuroID.captureEvent(
                     type = CALL_IN_PROGRESS,
                     cp = CallInProgress.ACTIVE.event,
@@ -92,7 +94,7 @@ class NIDCallActivityListener(
                 )
             }
             CallInProgress.RINGING.state -> {
-                NIDLog.d(msg = "Call Ringing")
+                logger.d(msg = "Call Ringing")
                 neuroID.captureEvent(
                     type = CALL_IN_PROGRESS,
                     cp = "$callStateActive",
@@ -110,7 +112,7 @@ class NIDCallActivityListener(
                 )
             }
             CallInProgress.UNAUTHORIZED.state -> {
-                NIDLog.d(msg = "Call status not authorized")
+                logger.d(msg = "Call status not authorized")
                 neuroID.captureEvent(
                     type = CALL_IN_PROGRESS,
                     cp = CallInProgress.UNAUTHORIZED.event,
@@ -118,7 +120,7 @@ class NIDCallActivityListener(
                 )
             }
             else -> {
-                NIDLog.d(msg = "Call status unknown")
+                logger.d(msg = "Call status unknown")
                 neuroID.captureEvent(
                     type = CALL_IN_PROGRESS,
                     cp = CallInProgress.UNKNOWN.event,
@@ -132,7 +134,7 @@ class NIDCallActivityListener(
     private fun registerCustomTelephonyCallback(context: Context) {
         val telephony = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
         if (versionChecker.isBuildVersionGreaterThanOrEqualTo31()) {
-            NIDLog.d(msg = "SDK >= 31")
+            logger.d(msg = "SDK >= 31")
             if (customTelephonyCallback == null) {
                 customTelephonyCallback = CustomTelephonyCallback { state ->
                     when (state) {
@@ -161,7 +163,7 @@ class NIDCallActivityListener(
                 )
             }
         } else {
-            NIDLog.d(msg = "SDK < 31")
+            logger.d(msg = "SDK < 31")
             if (phoneStateListener == null) {
                 phoneStateListener = object: PhoneStateListener() {
                     override fun onCallStateChanged(

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
@@ -9,7 +9,7 @@ import com.neuroid.tracker.events.OUT_OF_MEMORY
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.models.NIDResponseCallBack
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
-import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.neuroid.tracker.utils.generateUniqueHexID
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -35,6 +35,7 @@ interface NIDSendingService {
 class NIDEventSender(
     private var httpService: HttpService,
     private val context: Context,
+    private val logger: NIDLogWrapper = NIDLogWrapper()
 ) : NIDSendingService, RetrySender() {
     // a static payload to send if OOM occurs
     private var oomPayload = ""
@@ -74,7 +75,7 @@ class NIDEventSender(
 
             data = getRequestPayloadJSON(events)
 
-            NIDLog.d("Payload", msg = "payload size: ${data.length} bytes")
+            logger.d("Payload", msg = "payload size: ${data.length} bytes")
         } catch (exception: OutOfMemoryError) {
             // make a best effort attempt to continue and send an out of memory event
             data = oomPayload
@@ -134,7 +135,7 @@ class NIDEventSender(
                 "packetNumber" to packetNumber
             )
 
-        NIDLog.d(
+        logger.d(
             "Payload:",
             msg =
                 """
@@ -152,7 +153,7 @@ class NIDEventSender(
         )
 
         // using this JSON library (already included) does not escape /
-        NIDLog.i(msg = "NID logging events (${events.count()}) as linkedSiteID: $linkedSiteID")
+        logger.i(msg = "NID logging events (${events.count()}) as linkedSiteID: $linkedSiteID")
         val gson: Gson = GsonBuilder().create()
         return gson.toJson(jsonBody)
     }

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDLog.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDLog.kt
@@ -3,7 +3,7 @@ package com.neuroid.tracker.utils
 import android.util.Log
 import com.neuroid.tracker.NeuroID
 
-object NIDLog {
+class NIDLog {
     val nidTag = "NeuroID"
     val infoTag = "NeuroID Info"
     val debugTag = "NeuroID Debug"
@@ -12,61 +12,56 @@ object NIDLog {
 
     fun d(
         tag: String? = null,
-        msg: String,
-        cb: () -> String = { msg },
+        msg: String
     ) {
         if (NeuroID.showLogs && NeuroID.isSDKStarted) {
-            cb().chunked(900).forEach {
-                Log.d(appendTag(tag, debugTag), it)
-            }
+            Log.d(appendTag(tag, debugTag), msg)
         }
     }
 
     fun i(
         tag: String? = null,
-        msg: String,
-        cb: () -> String = { msg },
+        msg: String
     ) {
         if (NeuroID.showLogs) {
-            cb().chunked(900).forEach {
-                Log.d(appendTag(tag, infoTag), it)
-            }
+            Log.d(appendTag(tag, infoTag), msg)
         }
     }
 
     fun v(
         tag: String? = null,
-        msg: String,
-        cb: () -> String = { msg },
+        msg: String
     ) {
         if (NeuroID.showLogs) {
-            cb().chunked(900).forEach {
-                Log.d(appendTag(tag, nidTag), it)
-            }
+            Log.d(appendTag(tag, nidTag), msg)
         }
     }
 
     fun w(
         tag: String? = null,
         msg: String,
-        cb: () -> String = { msg },
     ) {
         if (NeuroID.showLogs) {
-            cb().chunked(900).forEach {
-                Log.d(appendTag(tag, warnTag), it)
-            }
+            Log.d(appendTag(tag, warnTag), msg)
         }
     }
 
     fun e(
         tag: String? = null,
         msg: String,
-        cb: () -> String = { msg },
     ) {
         if (NeuroID.showLogs) {
-            cb().chunked(900).forEach {
-                Log.d(appendTag(tag, errorTag), it)
-            }
+            Log.d(appendTag(tag, errorTag), msg)
+        }
+    }
+
+    fun printLine(
+        tag: String?,
+        logLevel: String,
+        msg: String,
+    ) {
+        if (NeuroID.showLogs) {
+            println("${appendTag(tag, logLevel)}, $msg" )
         }
     }
 
@@ -82,8 +77,10 @@ object NIDLog {
         }
     }
 
-    const val CHECK_BOX_CHANGE_TAG = "CheckBoxChange"
-    const val CHECK_BOX_ID = "CheckBoxID:"
-    const val RADIO_BUTTON_CHANGE_TAG = "RadioButtonChange"
-    const val RADIO_BUTTON_ID = "RadioButtonID:"
+    companion object {
+        const val CHECK_BOX_CHANGE_TAG = "CheckBoxChange"
+        const val CHECK_BOX_ID = "CheckBoxID:"
+        const val RADIO_BUTTON_CHANGE_TAG = "RadioButtonChange"
+        const val RADIO_BUTTON_ID = "RadioButtonID:"
+    }
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDLogWrapper.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDLogWrapper.kt
@@ -1,38 +1,80 @@
 package com.neuroid.tracker.utils
 
-class NIDLogWrapper {
+import com.neuroid.tracker.BuildConfig
+
+class NIDLogWrapper(val logger: NIDLog = NIDLog()) {
     fun d(
         tag: String? = null,
         msg: String,
+        buildType: String = BuildConfig.BUILD_TYPE,
+        cb: () -> String = { msg },
     ) {
-        NIDLog.d(tag, msg)
+        cb().chunked(900).forEach {
+            if (buildType.equals("release")) {
+                logger.printLine(tag, logger.debugTag, it)
+            } else {
+                logger.d(tag, it)
+            }
+        }
     }
 
     fun e(
         tag: String? = null,
         msg: String,
+        buildType: String = BuildConfig.BUILD_TYPE,
+        cb: () -> String = { msg },
     ) {
-        NIDLog.e(tag, msg)
+        cb().chunked(900).forEach {
+            if (buildType.equals("release")) {
+                logger.printLine(tag, logger.errorTag, it)
+            } else {
+                logger.e(tag, it)
+            }
+        }
     }
 
     fun i(
         tag: String? = null,
         msg: String,
+        buildType: String = BuildConfig.BUILD_TYPE,
+        cb: () -> String = { msg }
     ) {
-        NIDLog.i(tag, msg)
+        cb().chunked(900).forEach {
+            if (buildType.equals("release")) {
+                logger.printLine(tag, logger.infoTag, it)
+            } else {
+                logger.i(tag, it)
+            }
+        }
     }
 
     fun v(
         tag: String? = null,
         msg: String,
+        buildType: String = BuildConfig.BUILD_TYPE,
+        cb: () -> String = { msg }
     ) {
-        NIDLog.v(tag, msg)
+        cb().chunked(900).forEach {
+            if (buildType.equals("release")) {
+                logger.printLine(tag, logger.nidTag, it)
+            } else {
+                logger.v(tag, it)
+            }
+        }
     }
 
     fun w(
         tag: String? = null,
         msg: String,
+        buildType: String = BuildConfig.BUILD_TYPE,
+        cb: () -> String = { msg }
     ) {
-        NIDLog.w(tag, msg)
+        cb().chunked(900).forEach {
+            if (buildType.equals("release")) {
+                logger.printLine(tag, logger.warnTag, it)
+            } else {
+                logger.w(tag, it)
+            }
+        }
     }
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
@@ -137,7 +137,7 @@ class AdvancedDeviceIDManagerServiceTest {
         verifyCaptureEvent(mockedNID, ADVANCED_DEVICE_REQUEST, 1)
         verify(exactly = 1) {
             mockedSharedPreferences.getString(AdvancedDeviceIDManager.NID_RID, AdvancedDeviceIDManager.defaultCacheValue)
-            mockedLogger.d(msg = "Retrieving Request ID for Advanced Device Signals from cache: $keyValue")
+            mockedLogger.d(msg = "Retrieving Request ID for Advanced Device Signals from cache: $keyValue", cb = any())
         }
     }
 
@@ -167,7 +167,7 @@ class AdvancedDeviceIDManagerServiceTest {
         verifyCaptureEvent(mockedNID, LOG, 1)
         verifyCaptureEvent(mockedNID, ADVANCED_DEVICE_REQUEST_FAILED, 1)
         verify(exactly = 1) {
-            mockedLogger.e(msg = "Failed to get API key from NeuroID: $errorMessage")
+            mockedLogger.e(msg = "Failed to get API key from NeuroID: $errorMessage", cb = any())
         }
     }
 
@@ -205,10 +205,10 @@ class AdvancedDeviceIDManagerServiceTest {
 
         job?.invokeOnCompletion {
             verify(exactly = 1) {
-                mockedLogger.d(msg = "Error retrieving Advanced Device Signal Request ID:$errorMessage: 1")
-                mockedLogger.d(msg = "Error retrieving Advanced Device Signal Request ID:$errorMessage: 2")
-                mockedLogger.d(msg = "Error retrieving Advanced Device Signal Request ID:$errorMessage: 3")
-                mockedLogger.e(msg = "Reached maximum number of retries (3) to get Advanced Device Signal Request ID: FPJS Failure")
+                mockedLogger.d(msg = "Error retrieving Advanced Device Signal Request ID:$errorMessage: 1", cb = any())
+                mockedLogger.d(msg = "Error retrieving Advanced Device Signal Request ID:$errorMessage: 2", cb = any())
+                mockedLogger.d(msg = "Error retrieving Advanced Device Signal Request ID:$errorMessage: 3", cb = any())
+                mockedLogger.e(msg = "Reached maximum number of retries (3) to get Advanced Device Signal Request ID: FPJS Failure", cb = any())
                 mockedNeuroID.captureEvent(
                     type = "LOG",
                     ts = 0,
@@ -250,9 +250,9 @@ class AdvancedDeviceIDManagerServiceTest {
 
             job?.invokeOnCompletion {
                 verify(exactly = 1) {
-                    mockedLogger.d(msg = "Generating Request ID for Advanced Device Signals: $validRID")
+                    mockedLogger.d(msg = "Generating Request ID for Advanced Device Signals: $validRID", cb=any())
                     mockedNID.captureEvent(type = ADVANCED_DEVICE_REQUEST, rid = any(), ts = any(), c = false, l = 0, ct = any())
-                    mockedLogger.d(msg = "Caching Request ID: $validRID")
+                    mockedLogger.d(msg = "Caching Request ID: $validRID", cb = any())
                     mockedSharedPreferences.putString(AdvancedDeviceIDManager.NID_RID, any())
                 }
             }
@@ -334,8 +334,8 @@ class AdvancedDeviceIDManagerServiceTest {
 
     private fun getMockedLogger(): NIDLogWrapper {
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
         return logger
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/AndroidTestUtils.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AndroidTestUtils.kt
@@ -205,10 +205,10 @@ internal fun getMockedApplication(): Application {
 
 internal fun getMockedLogger(): NIDLogWrapper {
     val logger = mockk<NIDLogWrapper>()
-    every { logger.d(any(), any()) } just runs
-    every { logger.i(any(), any()) } just runs
-    every { logger.w(any(), any()) } just runs
-    every { logger.e(any(), any()) } just runs
+    every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+    every { logger.i(any(), any(), any(), any<() -> String>()) } just runs
+    every { logger.w(any(), any(), any(), any<() -> String>()) } just runs
+    every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
     return logger
 }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NIDAdvancedDeviceNetworkServiceUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NIDAdvancedDeviceNetworkServiceUnitTests.kt
@@ -132,6 +132,7 @@ class NIDAdvancedDeviceNetworkServiceUnitTests {
             mockedLogger.d(
                 tag = "NeuroID ADV",
                 msg = "Failed to get API key from NeuroID: $errorMessage - Code: ${400}. Retrying: ${true}",
+                cb = any()
             )
         }
 
@@ -139,6 +140,7 @@ class NIDAdvancedDeviceNetworkServiceUnitTests {
             mockedLogger.d(
                 tag = "NeuroID ADV",
                 msg = "Failed to get API key from NeuroID: $errorMessage - Code: ${400}. Retrying: ${false}",
+                cb = any()
             )
         }
     }
@@ -202,8 +204,8 @@ class NIDAdvancedDeviceNetworkServiceUnitTests {
 
     private fun getMockedLogger(): NIDLogWrapper {
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
         return logger
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -81,7 +81,7 @@ open class NeuroIDClassUnitTests {
     ) {
         val log = mockk<NIDLogWrapper>()
 
-        every { log.e(any(), any()) } answers {
+        every { log.e(any(), any(), any(), any<() -> String>()) } answers {
             val actualMessage = args[1]
             assertLogMessage(TestLogLevel.ERROR, errorMessage, actualMessage)
 
@@ -89,7 +89,7 @@ open class NeuroIDClassUnitTests {
             actualMessage
         }
 
-        every { log.i(any(), any()) } answers {
+        every { log.i(any(), any(), any(), any<() -> String>()) } answers {
             val actualMessage = args[1]
             assertLogMessage(TestLogLevel.INFO, infoMessage, actualMessage)
 
@@ -97,7 +97,7 @@ open class NeuroIDClassUnitTests {
             actualMessage
         }
 
-        every { log.d(any(), any()) } answers {
+        every { log.d(any(), any(), any(), any<() -> String>()) } answers {
             val actualMessage = args[1]
             assertLogMessage(TestLogLevel.DEBUG, debugMessage, actualMessage)
 
@@ -105,7 +105,7 @@ open class NeuroIDClassUnitTests {
             actualMessage
         }
 
-        every { log.w(any(), any()) } answers {
+        every { log.w(any(), any(), any(), any<() -> String>()) } answers {
             val actualMessage = args[1]
             assertLogMessage(TestLogLevel.WARNING, warningMessage, actualMessage)
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
@@ -122,7 +122,7 @@ class NeuroIdUnitTest {
         every { viewGroup.id } returns 11
         every { view.parent } returns viewGroup
         val log = mockk<NIDLogWrapper>()
-        justRun { log.e(any(), any()) }
+        justRun { log.e(any(), any(), any(), any<() -> String>()) }
         val viewReal = View(context)
         val label = viewReal.getParentsOfView(0, view, log)
         // need to use matcher, class.simpleName() returns random numbers in the when mocked
@@ -145,7 +145,7 @@ class NeuroIdUnitTest {
         every { viewGroup.id } returns 10
         every { view.parent } returns viewGroup
         val log = mockk<NIDLogWrapper>()
-        justRun { log.e(any(), any()) }
+        justRun { log.e(any(), any(), any(), any<() -> String>()) }
         val viewReal = View(context)
         val label = viewReal.getParentsOfView(0, view, log)
         // need to use matcher, class.simpleName() returns random numbers in the when mocked

--- a/NeuroID/src/test/java/com/neuroid/tracker/callbacks/ActivityCallbacksUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/callbacks/ActivityCallbacksUnitTests.kt
@@ -50,7 +50,7 @@ internal class ActivityCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onActivityCreated",
+                msg = "onActivityCreated", cb = any()
             )
         }
     }
@@ -85,19 +85,19 @@ internal class ActivityCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Activity - Created",
+                msg = "Activity - Created", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "onActivityStarted existActivity.not()",
+                msg = "onActivityStarted existActivity.not()", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Activity - POST Created - REGISTER FRAGMENT LIFECYCLES",
+                msg = "Activity - POST Created - REGISTER FRAGMENT LIFECYCLES", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Activity - POST Created - Window Load",
+                msg = "Activity - POST Created - Window Load", cb = any()
             )
         }
 
@@ -146,23 +146,23 @@ internal class ActivityCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Activity - Created",
+                msg = "Activity - Created", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "onActivityStarted existActivity.not()",
+                msg = "onActivityStarted existActivity.not()", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Activity - POST Created - REGISTER FRAGMENT LIFECYCLES",
+                msg = "Activity - POST Created - REGISTER FRAGMENT LIFECYCLES", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Activity - POST Created - Orientation change",
+                msg = "Activity - POST Created - Orientation change", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Activity - POST Created - Window Load",
+                msg = "Activity - POST Created - Window Load", cb = any()
             )
         }
 
@@ -192,7 +192,7 @@ internal class ActivityCallbacksUnitTests {
         val expectedActivityName = mocks.mockedActivity::class.java.name
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Activity - Paused",
+                msg = "Activity - Paused", cb = any()
             )
         }
 
@@ -222,7 +222,7 @@ internal class ActivityCallbacksUnitTests {
         if (!BuildConfig.FLAVOR.contains("react")) {
             verify(exactly = 1) {
                 mocks.mockedLogger.d(
-                    msg = "Activity - Resumed",
+                    msg = "Activity - Resumed", cb = any()
                 )
 
                 mocks.mockedRegistration.registerTargetFromScreen(
@@ -260,7 +260,7 @@ internal class ActivityCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Activity - Stopped",
+                msg = "Activity - Stopped", cb = any()
             )
         }
     }
@@ -274,7 +274,7 @@ internal class ActivityCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Activity - Save Instance",
+                msg = "Activity - Save Instance", cb = any()
             )
         }
     }
@@ -289,11 +289,11 @@ internal class ActivityCallbacksUnitTests {
         val expectedActivityName = mocks.mockedActivity::class.java.name
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Activity - Destroyed",
+                msg = "Activity - Destroyed", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Activity - Destroyed - Window Unload",
+                msg = "Activity - Destroyed - Window Unload", cb = any()
             )
         }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/callbacks/FragmentCallbacksUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/callbacks/FragmentCallbacksUnitTests.kt
@@ -49,7 +49,7 @@ internal class FragmentCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentAttached $expectedActivityName",
+                msg = "onFragmentAttached $expectedActivityName", cb = any()
             )
 
             mocks.mockedRegistration.registerTargetFromScreen(
@@ -116,7 +116,7 @@ internal class FragmentCallbacksUnitTests {
 
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentAttached $expectedActivityName",
+                msg = "onFragmentAttached $expectedActivityName", cb = any()
             )
         }
 
@@ -161,7 +161,7 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentViewCreated $expectedActivityName",
+                msg = "onFragmentViewCreated $expectedActivityName", cb = any()
             )
         }
     }
@@ -181,7 +181,7 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentViewCreated $expectedActivityName",
+                msg = "onFragmentViewCreated $expectedActivityName", cb = any()
             )
         }
     }
@@ -199,11 +199,11 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Fragment - Resumed ${1} ${false} ${"tag"} $expectedActivityName",
+                msg = "Fragment - Resumed ${1} ${false} ${"tag"} $expectedActivityName", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Fragment - Resumed - REGISTER TARGET $expectedActivityName",
+                msg = "Fragment - Resumed - REGISTER TARGET $expectedActivityName", cb = any()
             )
 
             mocks.mockedNeuroID.shouldForceStart()
@@ -230,7 +230,7 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Fragment - Resumed ${1} ${false} ${"tag"} $expectedActivityName",
+                msg = "Fragment - Resumed ${1} ${false} ${"tag"} $expectedActivityName", cb = any()
             )
 
             mocks.mockedNeuroID.shouldForceStart()
@@ -264,7 +264,7 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentPaused $expectedActivityName",
+                msg = "onFragmentPaused $expectedActivityName", cb = any()
             )
         }
     }
@@ -282,7 +282,7 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentStopped $expectedActivityName",
+                msg = "onFragmentStopped $expectedActivityName", cb = any()
             )
         }
     }
@@ -300,7 +300,7 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "onFragmentDestroyed $expectedActivityName",
+                msg = "onFragmentDestroyed $expectedActivityName" , cb = any()
             )
         }
     }
@@ -318,11 +318,11 @@ internal class FragmentCallbacksUnitTests {
         val expectedActivityName = mocks.mockedFragment::class.java.simpleName
         verify(exactly = 1) {
             mocks.mockedLogger.d(
-                msg = "Fragment - Detached $expectedActivityName",
+                msg = "Fragment - Detached $expectedActivityName", cb = any()
             )
 
             mocks.mockedLogger.d(
-                msg = "Fragment - Detached - WINDOW UNLOAD $expectedActivityName",
+                msg = "Fragment - Detached - WINDOW UNLOAD $expectedActivityName", cb = any()
             )
         }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/callbacks/SensorHelperTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/callbacks/SensorHelperTests.kt
@@ -26,7 +26,7 @@ class SensorHelperTests {
     // mock setup functions
     fun setupMockLogger(): NIDLogWrapper {
         val logger = mockk<NIDLogWrapper>()
-        every { logger.i(any(), any()) } just runs
+        every { logger.i(any(), any(), any(), any<() -> String>()) } just runs
 
         return logger
     }
@@ -202,7 +202,7 @@ class SensorHelperTests {
         NIDSensorHelper.initSensorHelper(context, logger, nidSensors)
 
         // is it the proper sensor?
-        verify { logger.i("NeuroID SensorHelper", "Sensor:gyro 4") }
+        verify { logger.i("NeuroID SensorHelper", "Sensor:gyro 4", cb = any()) }
         // did we register the listener?
         verifySensorPair(sensorPair)
     }
@@ -218,7 +218,7 @@ class SensorHelperTests {
         NIDSensorHelper.initSensorHelper(context, logger, nidSensors)
 
         // is it the proper sensor?
-        verify { logger.i("NeuroID SensorHelper", "Sensor:accel 1") }
+        verify { logger.i("NeuroID SensorHelper", "Sensor:accel 1", cb = any()) }
         // did we register the listener?
         verifySensorPair(sensorPair)
     }

--- a/NeuroID/src/test/java/com/neuroid/tracker/events/NIDIdentityAllViewsTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/events/NIDIdentityAllViewsTest.kt
@@ -36,8 +36,8 @@ class NIDIdentityAllViewsTest {
         every { editText.getCustomSelectionActionModeCallback() } returns null
         every { editText.setCustomSelectionActionModeCallback(any()) } just runs
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
 
         val nidMock = getMockedNeuroID()
 
@@ -46,7 +46,7 @@ class NIDIdentityAllViewsTest {
         verify {
             logger.d(
                 "NID test output",
-                "etn: INPUT, et: EditText, eid: edit text 1, v:S~C~~23",
+                "etn: INPUT, et: EditText, eid: edit text 1, v:S~C~~23", cb = any()
             )
         }
     }
@@ -61,8 +61,8 @@ class NIDIdentityAllViewsTest {
         every { toggleButton.parent } returns null
 
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
 
         val nidMock = getMockedNeuroID()
 
@@ -71,7 +71,7 @@ class NIDIdentityAllViewsTest {
         verify {
             logger.d(
                 "NID test output",
-                "etn: INPUT, et: ToggleButton, eid: toggle button 1, v:S~C~~0",
+                "etn: INPUT, et: ToggleButton, eid: toggle button 1, v:S~C~~0", cb = any()
             )
         }
     }
@@ -86,8 +86,8 @@ class NIDIdentityAllViewsTest {
         every { switchCompat.parent } returns null
 
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>())} just runs
+        every { logger.e(any(), any(), any(), any<() -> String>())} just runs
 
         val nidMock = getMockedNeuroID()
 
@@ -96,7 +96,7 @@ class NIDIdentityAllViewsTest {
         verify {
             logger.d(
                 "NID test output",
-                "etn: INPUT, et: SwitchCompat, eid: switch compat, v:S~C~~0",
+                "etn: INPUT, et: SwitchCompat, eid: switch compat, v:S~C~~0", cb = any()
             )
         }
     }
@@ -111,8 +111,8 @@ class NIDIdentityAllViewsTest {
         every { imageButton.parent } returns null
 
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
 
         val nidMock = getMockedNeuroID()
 
@@ -121,7 +121,7 @@ class NIDIdentityAllViewsTest {
         verify {
             logger.d(
                 "NID test output",
-                "etn: INPUT, et: ImageButton, eid: image button, v:S~C~~0",
+                "etn: INPUT, et: ImageButton, eid: image button, v:S~C~~0", cb = any()
             )
         }
     }
@@ -136,14 +136,14 @@ class NIDIdentityAllViewsTest {
         every { seekBar.parent } returns null
 
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
 
         val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
-        verify { logger.d("NID test output", "etn: INPUT, et: SeekBar, eid: seek bar, v:S~C~~0") }
+        verify { logger.d("NID test output", "etn: INPUT, et: SeekBar, eid: seek bar, v:S~C~~0", cb = any()) }
     }
 
     @Test
@@ -156,8 +156,8 @@ class NIDIdentityAllViewsTest {
         every { ratingBar.parent } returns null
 
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
 
         val nidMock = getMockedNeuroID()
 
@@ -166,7 +166,7 @@ class NIDIdentityAllViewsTest {
         verify {
             logger.d(
                 "NID test output",
-                "etn: INPUT, et: RatingBar, eid: rating bar, v:S~C~~0",
+                "etn: INPUT, et: RatingBar, eid: rating bar, v:S~C~~0", cb = any()
             )
         }
     }
@@ -204,18 +204,18 @@ class NIDIdentityAllViewsTest {
         every { radioButton.parent } returns radioButtonViewParent
 
         val logger = mockk<NIDLogWrapper>()
-        every { logger.d(any(), any()) } just runs
-        every { logger.e(any(), any()) } just runs
+        every { logger.d(any(), any(), any(), any<() -> String>()) } just runs
+        every { logger.e(any(), any(), any(), any<() -> String>()) } just runs
 
         val nidMock = getMockedNeuroID()
 
         val registrationIdentificationHelper = RegistrationIdentificationHelper(nidMock, logger)
         registrationIdentificationHelper.identifySingleView(view, "someguid")
-        verify { logger.d("NID test output", "etn: INPUT, et: RadioGroup, eid: RadioGroup, v:12") }
+        verify { logger.d("NID test output", "etn: INPUT, et: RadioGroup, eid: RadioGroup, v:12", cb = any()) }
         verify(exactly = 2) {
             logger.d(
                 "NID test output",
-                "etn: INPUT, et: RadioButton, eid: RadioButton, v:true",
+                "etn: INPUT, et: RadioButton, eid: RadioButton, v:true", cb = any()
             )
         }
     }

--- a/NeuroID/src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt
@@ -173,7 +173,7 @@ class NIDDataStoreManagerUnitTests {
         val serviceConfig = mockk<ConfigService>()
         every { serviceConfig.configCache } returns NIDRemoteConfig()
         val logger = mockk<NIDLogWrapper>()
-        every {logger.d(any(), any())} just runs
+        every {logger.d(any(), any(), any(), any<() -> String>())} just runs
         val dataStore = NIDDataStoreManagerImp(logger, serviceConfig)
         val raceConditionedEventList = mockk<MutableList<NIDEventModel>>()
         every {raceConditionedEventList.size} returns 0
@@ -182,6 +182,6 @@ class NIDDataStoreManagerUnitTests {
         every {raceConditionedEventList.add(any())} returns true
         dataStore.eventsList = raceConditionedEventList
         assert(!dataStore.isFullBuffer())
-        verify{logger.d(any(), "possible emptying before calling eventsList.last() after empty check occurred list is empty fool!")}
+        verify{logger.d(any(), "possible emptying before calling eventsList.last() after empty check occurred list is empty fool!", cb = any())}
     }
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/utils/NIDLogTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/utils/NIDLogTest.kt
@@ -1,0 +1,107 @@
+package com.neuroid.tracker.utils
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class NIDLogTest {
+    fun getNIDLog(): NIDLog {
+        val logger = mockk<NIDLog>()
+        every { logger.v(any(), any()) } just Runs
+        every { logger.e(any(), any()) } just Runs
+        every { logger.i(any(), any()) } just Runs
+        every { logger.w(any(), any()) } just Runs
+        every { logger.d(any(), any(), ) } just Runs
+        every { logger.nidTag} returns "NID"
+        every { logger.errorTag} returns "error"
+        every { logger.infoTag} returns "info"
+        every { logger.warnTag} returns "warn"
+        every { logger.debugTag} returns "debug"
+        every { logger.warnTag} returns "warn"
+        every { logger.printLine(any(), any(), any() ) } just Runs
+        return logger
+    }
+
+    @Test
+    fun testLoggerVerboseNonRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.v( msg = " test", buildType = "debug")
+        verify { logger.v(any(), any()) }
+    }
+
+    @Test
+    fun testLoggerVerboseRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.v( msg = "test", buildType = "release")
+        verify { logger.printLine(any(), any(), any()) }
+    }
+
+    @Test
+    fun testLoggerErrorNonRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.e( msg = " test", buildType = "debug")
+        verify { logger.e(any(), any()) }
+    }
+
+    @Test
+    fun testLoggerErrorRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.e( msg = "test", buildType = "release")
+        verify { logger.printLine(any(), any(), any()) }
+    }
+
+    @Test
+    fun testLoggerInfoNonRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.i( msg = " test", buildType = "debug")
+        verify { logger.i(any(), any()) }
+    }
+
+    @Test
+    fun testLoggerInfoRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.i( msg = "test", buildType = "release")
+        verify { logger.printLine(any(), any(), any()) }
+    }
+
+    @Test
+    fun testLoggerWarnNonRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.w( msg = " test", buildType = "debug")
+        verify { logger.w(any(), any()) }
+    }
+
+    @Test
+    fun testLoggerWarnRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.w( msg = "test", buildType = "release")
+        verify { logger.printLine(any(), any(), any()) }
+    }
+
+    @Test
+    fun testLoggerDebugNonRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.d( msg = " test", buildType = "debug")
+        verify { logger.d(any(), any()) }
+    }
+
+    @Test
+    fun testLoggerDebugRelease() {
+        val logger = getNIDLog()
+        val t = NIDLogWrapper(logger)
+        t.d( msg = "test", buildType = "release")
+        verify { logger.printLine(any(), any(), any()) }
+    }
+}

--- a/app/src/androidTest/java/com/sample/neuroid/us/ComponentsTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/ComponentsTest.kt
@@ -12,6 +12,7 @@ import androidx.test.filters.LargeTest
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.storage.getTestingDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.activities.MainActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -62,8 +63,8 @@ class ComponentsTest {
     fun test01ValidateCheckBox() = runTest(timeout = Duration.parse("120s")) {
         Looper.prepare()
         NeuroID.getInstance()?.start()
-
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
 
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
@@ -81,7 +82,8 @@ class ComponentsTest {
      */
     @Test
     fun test02ValidateRadioChange() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
 
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
@@ -99,7 +101,8 @@ class ComponentsTest {
      */
     @Test
     fun test03ValidateSwitch() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
 
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
@@ -120,7 +123,8 @@ class ComponentsTest {
      */
     @Test
     fun test04ValidateToggle() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
 
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
@@ -141,7 +145,8 @@ class ComponentsTest {
      */
     @Test
     fun test05ValidateRatingBar() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
 
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
@@ -163,7 +168,8 @@ class ComponentsTest {
      */
     @Test
     fun test06ValidateSliderChange() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
 
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())

--- a/app/src/androidTest/java/com/sample/neuroid/us/NeuroIdUITest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/NeuroIdUITest.kt
@@ -13,6 +13,7 @@ import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.storage.getTestingDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.activities.MainActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -48,6 +49,7 @@ data class ResponseData(
 @LargeTest
 @ExperimentalCoroutinesApi
 class NeuroIdUITest: MockServerTest() {
+    val logger = NIDLogWrapper()
 
     // take care of the phone and location permissions dialogs.
     @get:Rule
@@ -79,7 +81,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test01ValidateCreateSession() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.start()
         delay(500)
 
@@ -92,7 +94,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test02ValidateRegisterTargets() = runTest(timeout = Duration.parse("120s"))  {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
         delay(1000) //Wait a half second for create the MainActivity View
@@ -106,7 +108,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test03ValidateSetUserId() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.setUserID("UUID1234")
         delay(500)
 
@@ -119,7 +121,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test03aValidateSetRegisteredUserId() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.setRegisteredUserID("UUID1234")
         delay(500)
 
@@ -132,7 +134,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test04ValidateLifecycleStart() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
         delay(500)
@@ -146,7 +148,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test05ValidateLifecycleResume() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         onView(withId(R.id.button_show_activity_one_fragment))
             .perform(click())
 
@@ -159,7 +161,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test06ValidateLifecyclePause() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
 
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500)
@@ -177,7 +179,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test07ValidateLifecycleStop() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500)
         onView(withId(R.id.button_show_activity_one_fragment))
@@ -196,7 +198,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test08ValidateTouchStart() {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(200) // When you go to the next test, the activity is destroyed and recreated
         onView(withId(R.id.button_show_activity_fragments))
@@ -216,7 +218,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test09ValidateTouchEnd() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) // When you go to the next test, the activity is destroyed and recreated
         onView(withId(R.id.button_show_activity_fragments))
@@ -235,7 +237,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test11ValidateSwipeScreen() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         // TODO
         // Implement swipe test
     }
@@ -245,7 +247,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test12ValidateWindowsResize() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) // When you go to the next test, the activity is destroyed and recreated
         onView(withId(R.id.button_show_activity_fragments))
@@ -266,7 +268,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test13ValidateTouchStartAddsRegisterEvent() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) // When you go to the next test, the activity is destroyed and recreated
         onView(withId(R.id.button_show_activity_fragments))
@@ -283,7 +285,7 @@ class NeuroIdUITest: MockServerTest() {
      */
     @Test
     fun test14ValidateSetUserIdPreStart() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         NeuroID.getInstance()?.stop()
         delay(500)
@@ -301,7 +303,7 @@ class NeuroIdUITest: MockServerTest() {
     */
     @Test
     fun test15ValidateSetRegisteredUserIdPreStart() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.stop()
         delay(500)
         NeuroID.getInstance()?.setRegisteredUserID("UUID1231212")

--- a/app/src/androidTest/java/com/sample/neuroid/us/SandBoxTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/SandBoxTest.kt
@@ -13,6 +13,7 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.activities.sandbox.SandBoxActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -29,6 +30,7 @@ import kotlin.time.Duration
 @LargeTest
 @ExperimentalCoroutinesApi
 class SandBoxTest {
+    val logger = NIDLogWrapper()
     companion object {
         @BeforeClass
         @JvmStatic
@@ -65,7 +67,7 @@ class SandBoxTest {
      */
     @Test
     fun test01RiskyScore() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        logger.d("----> UITest", "-------------------------------------------------")
         val firstNameField = onView(withId(R.id.firstName))
         val lastNameField = onView(withId(R.id.lastName))
         val emailField = onView(withId(R.id.email))

--- a/app/src/androidTest/java/com/sample/neuroid/us/TextUnitTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/TextUnitTest.kt
@@ -11,6 +11,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.storage.getTestingDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.activities.MainActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -56,7 +57,8 @@ class TextUnitTest: MockServerTest() {
      */
     @Test
     fun test01ValidateFocusOnEditText() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) // When you go to the next test, the activity is destroyed and recreated
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
@@ -76,7 +78,8 @@ class TextUnitTest: MockServerTest() {
      */
     @Test
     fun test02ValidateBlurOnEditText() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) // When you go to the next test, the activity is destroyed and recreated
         Espresso.onView(ViewMatchers.withId(R.id.button_show_activity_fragments))
@@ -98,7 +101,8 @@ class TextUnitTest: MockServerTest() {
      */
     @Test
     fun test03ValidateInputText() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) // When you go to the next test, the activity is destroyed and recreated
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()

--- a/app/src/androidTest/java/com/sample/neuroid/us/activities/DynamicActivityTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/activities/DynamicActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.test.filters.LargeTest
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.storage.getTestingDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.MockServerTest
 import com.sample.neuroid.us.R
 import com.sample.neuroid.us.delay
@@ -45,7 +46,8 @@ class DynamicActivityTest: MockServerTest() {
 
     @Test
     fun test01ValidateFormSubmit() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("debug","----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         Espresso.onView(ViewMatchers.withId(R.id.btnAdd))
             .perform(click())

--- a/app/src/androidTest/java/com/sample/neuroid/us/activities/LifeCycleTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/activities/LifeCycleTest.kt
@@ -8,6 +8,7 @@ import androidx.test.uiautomator.UiDevice
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.storage.getTestingDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.MockServerTest
 import com.sample.neuroid.us.delay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,7 +49,8 @@ class LifeCycleTest: MockServerTest() {
      */
     @Test
     fun test13ValidateChangeScreenOrientation() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("debug","----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 

--- a/app/src/androidTest/java/com/sample/neuroid/us/activities/NonAutomaticEventsTest.kt
+++ b/app/src/androidTest/java/com/sample/neuroid/us/activities/NonAutomaticEventsTest.kt
@@ -9,6 +9,7 @@ import androidx.test.filters.LargeTest
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.storage.getTestingDataStoreInstance
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.MockServerTest
 import com.sample.neuroid.us.R
 import com.sample.neuroid.us.delay
@@ -51,7 +52,8 @@ class NonAutomaticEventsTest: MockServerTest() {
      */
     @Test
     fun test01ValidateFormSubmit() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("debug","----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500)
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
@@ -67,7 +69,8 @@ class NonAutomaticEventsTest: MockServerTest() {
      */
     @Test
     fun test02ValidateFormSubmitSuccess() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("debug","----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) //Wait a half second for create the MainActivity View
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
@@ -84,7 +87,8 @@ class NonAutomaticEventsTest: MockServerTest() {
      */
     @Test
     fun test03ValidateFormSubmitFailure() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("debug","----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) //Wait a half second for create the MainActivity View
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
@@ -102,7 +106,8 @@ class NonAutomaticEventsTest: MockServerTest() {
     @Test
     @Ignore
     fun test04ValidateFormCustomEvent() = runTest(timeout = Duration.parse("120s")) {
-        NIDLog.d("----> UITest", "-------------------------------------------------")
+        val logger = NIDLogWrapper()
+        logger.d("debug","----> UITest", "-------------------------------------------------")
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()
         delay(500) //Wait a half second for create the MainActivity View
         NeuroID.getInstance()?.getTestingDataStoreInstance()?.clearEvents()

--- a/app/src/debug/java/com/sample/neuroid/us/activities/MainActivity.kt
+++ b/app/src/debug/java/com/sample/neuroid/us/activities/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.core.app.ActivityCompat
 import androidx.databinding.DataBindingUtil
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.R
 import com.sample.neuroid.us.activities.sandbox.SandBoxActivity
 import com.sample.neuroid.us.databinding.NidActivityMainBinding
@@ -95,6 +96,7 @@ class MainActivity : AppCompatActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        val logger = NIDLogWrapper()
         when(requestCode) {
             REQUEST_CODE -> {
                 if (isLocationPermissionGiven()) {
@@ -109,9 +111,9 @@ class MainActivity : AppCompatActivity() {
                     )
                 }
                 if (isCallActivityPermissionGiven()) {
-                    NIDLog.d(msg = "call activity permission granted")
+                    logger.d("debug",msg = "call activity permission granted")
                 } else {
-                    NIDLog.d(msg = "call activity permission denied")
+                    logger.d("debug",msg = "call activity permission denied")
                 }
             }
         }

--- a/app/src/debug/java/com/sample/neuroid/us/activities/NIDPayloadJsonActivity.kt
+++ b/app/src/debug/java/com/sample/neuroid/us/activities/NIDPayloadJsonActivity.kt
@@ -6,11 +6,13 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.utils.NIDLog
+import com.neuroid.tracker.utils.NIDLogWrapper
 import com.sample.neuroid.us.R
 import com.sample.neuroid.us.databinding.NidActivityJsonPayloadBinding
 
 class NIDPayloadJsonActivity : AppCompatActivity() {
     private lateinit var binding: NidActivityJsonPayloadBinding
+    val logger = NIDLogWrapper()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,7 +27,7 @@ class NIDPayloadJsonActivity : AppCompatActivity() {
 
         binding.apply {
             buttonShowPayloadJson.setOnClickListener {
-                NIDLog.d(msg = "Payload json: null")
+                logger.d("debug",msg = "Payload json: null")
             }
 
             buttonResetPayloadJson.setOnClickListener {


### PR DESCRIPTION
Enable obfuscation on Android SDK release builds. Changes were made in the logging wrapper to enable logging for release builds. ProGuard will strip out logging lines (`Log.x`) on mimification. Tried to turn this behavior off in proguard without success. As a work around, since `println` are not removed on mimification, a change in the NIDLogWrapper was made to use `println` if build type is release else using `Log.x`. In order to get unit tests working for this, the chunking was moved from `NIDLog` to `NIDLogWrapper`(`BuildConfig`, `println` and `Log.x` calls cannot be mocked). This required a logging code refactor on nearly all the classes. This PR is large but relatively simple with mainly logging changes where logging is called and the unit test. As a happy consequence, we now have unit tests for logging. Ping me and I can walk you through this one. 

Also, the GSON version was updated to 2.11 that fixes ProGuard issues with `TypeToken` usage in `AdvancedDeviceIDManager`. 

Tested on Layout sample app with Compose Login screen and the existing Integration sample app. 