### PR TITLE
ENG-9437 obfuscation

### DIFF
--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -52,7 +52,7 @@ android {
             buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField "String", "VERSION_NAME", "${defaultConfig.versionName}"
             buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
@@ -119,7 +119,7 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.lifecycle:lifecycle-process:2.4.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'

--- a/NeuroID/proguard-rules.pro
+++ b/NeuroID/proguard-rules.pro
@@ -20,11 +20,42 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--assumenosideeffects class android.util.Log {
-    public static boolean isLoggable(java.lang.String, int);
-    public static int v(...);
-    public static int d(...);
-    public static int i(...);
-    public static int e(...);
-    public static int w(...);
+# Uncomment to remove logging from release builds.
+#-assumenosideeffects class android.util.Log {
+#    public static boolean isLoggable(java.lang.String, int);
+#    public static int v(...);
+#    public static int d(...);
+#    public static int i(...);
+#    public static int e(...);
+#    public static int w(...);
+#}
+
+-keepattributes Signature
+-keepattributes *Annotation*
+
+-keep class com.google.gson.** { *; }
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.SerializedName <fields>;
 }
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.Expose <fields>;
+}
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.Since <fields>;
+}
+
+-keepclassmembers class * {
+    @com.google.gson.annotations.Until <fields>;
+}
+
+# have to keep these classes
+-keep class com.neuroid.tracker.models.** { *; }
+-keep class com.neuroid.tracker.events.** { *; }
+-keep interface com.neuroid.tracker.NeuroIDPublic { *; }
+-keep class com.neuroid.tracker.NeuroID { *; }
+-keep interface com.neuroid.tracker.compose.JetpackCompose { *; }
+-keep class com.neuroid.tracker.NeuroID$Companion { *; }
+-keep class com.neuroid.tracker.NeuroID$Builder { *; }


### PR DESCRIPTION
Enable obfuscation on Android SDK release builds. 

The GSON version was updated to 2.11 that fixes ProGuard issues with TypeToken usage in AdvancedDeviceIDManager.

Tested on Layout sample app with Compose Login screen and the existing Integration sample app.

Below is the contents of the classes . As you can see below the classes have been obfuscated except for classes that are accessed directly by host apps or classes that are accessed via reflection (serialized for use in network applications or views accessed through the activity lifecycle) . 
```
➜  "3.5.2" jar -xvf android-sdk-\"3.5.2\".aar 
 inflated: R.txt
 inflated: AndroidManifest.xml
 inflated: classes.jar
 inflated: proguard.txt
 inflated: META-INF/com/android/build/gradle/aar-metadata.properties
➜  "3.5.2" jar -xvf classes.jar 
 inflated: a/a.class
 inflated: a/b.class
 inflated: a/c.class
 inflated: a/d.class
 inflated: b/a.class
 inflated: b/b.class
 inflated: b/c.class
 inflated: b/d.class
 inflated: b/e.class
 inflated: b/f.class
 inflated: b/g.class
 inflated: b/h.class
 inflated: b/i.class
 inflated: b/j.class
 inflated: b/k.class
 inflated: b/l.class
 inflated: b/m.class
 inflated: b/n.class
 inflated: b/o.class
 inflated: c/a.class
 inflated: c/b.class
 inflated: c/c.class
 inflated: c/d.class
 inflated: c/e.class
 inflated: c/f.class
 inflated: c/g.class
 inflated: c/h.class
 inflated: com/neuroid/tracker/NeuroID$Builder.class
 inflated: com/neuroid/tracker/NeuroID$Companion.class
 inflated: com/neuroid/tracker/NeuroID.class
 inflated: com/neuroid/tracker/NeuroIDPublic.class
 inflated: com/neuroid/tracker/compose/JetpackCompose.class
 inflated: com/neuroid/tracker/events/AdditionalListeners$addOnHierarchyChangeListener$1.class
 inflated: com/neuroid/tracker/events/AdditionalListeners$addSelectOnSelect$1.class
 inflated: com/neuroid/tracker/events/AdditionalListeners.class
 inflated: com/neuroid/tracker/events/CallInProgress.class
 inflated: com/neuroid/tracker/events/ComponentValuesResult.class
 inflated: com/neuroid/tracker/events/MotionEventValues.class
 inflated: com/neuroid/tracker/events/NIDConstantsKt.class
 inflated: com/neuroid/tracker/events/NIDIdentifyViewsKt.class
 inflated: com/neuroid/tracker/events/RegistrationIdentificationHelper.class
 inflated: com/neuroid/tracker/events/RegistrationIdentificationHelperKt.class
 inflated: com/neuroid/tracker/events/SingleTargetListenerRegister$registerComponent$1.class
 inflated: com/neuroid/tracker/events/SingleTargetListenerRegister$registerComponent$2.class
 inflated: com/neuroid/tracker/events/SingleTargetListenerRegister$registerFinalComponent$1.class
 inflated: com/neuroid/tracker/events/SingleTargetListenerRegister.class
 inflated: com/neuroid/tracker/events/TouchEventManager.class
 inflated: com/neuroid/tracker/events/TouchEventManagerKt.class
 inflated: com/neuroid/tracker/models/ADVKeyFunctionResponse.class
 inflated: com/neuroid/tracker/models/ADVKeyNetworkResponse.class
 inflated: com/neuroid/tracker/models/ApplicationMetaData.class
 inflated: com/neuroid/tracker/models/DeviceOrientation.class
 inflated: com/neuroid/tracker/models/IntegrationHealthDeviceInfo.class
 inflated: com/neuroid/tracker/models/NIDEventModel$log$1.class
 inflated: com/neuroid/tracker/models/NIDEventModel.class
 inflated: com/neuroid/tracker/models/NIDLinkedSiteOption.class
 inflated: com/neuroid/tracker/models/NIDLocation.class
 inflated: com/neuroid/tracker/models/NIDRemoteConfig.class
 inflated: com/neuroid/tracker/models/NIDResponseCallBack.class
 inflated: com/neuroid/tracker/models/NIDSensorModel.class
 inflated: com/neuroid/tracker/models/NIDTouchModel.class
 inflated: com/neuroid/tracker/models/SessionIDOriginResult.class
 inflated: com/neuroid/tracker/models/SessionStartResult.class
 inflated: d/a.class
 inflated: d/b.class
 inflated: d/c.class
 inflated: e/a.class
 inflated: e/a0.class
 inflated: e/b.class
 inflated: e/b0.class
 inflated: e/c.class
 inflated: e/c0.class
 inflated: e/d.class
 inflated: e/d0.class
 inflated: e/e.class
 inflated: e/e0.class
 inflated: e/f.class
 inflated: e/f0.class
 inflated: e/g.class
 inflated: e/g0.class
 inflated: e/h.class
 inflated: e/h0.class
 inflated: e/i.class
 inflated: e/i0.class
 inflated: e/j.class
 inflated: e/j0.class
 inflated: e/k.class
 inflated: e/k0.class
 inflated: e/l.class
 inflated: e/l0.class
 inflated: e/m.class
 inflated: e/m0.class
 inflated: e/n.class
 inflated: e/n0.class
 inflated: e/o.class
 inflated: e/o0.class
 inflated: e/p.class
 inflated: e/p0.class
 inflated: e/q.class
 inflated: e/q0.class
 inflated: e/r.class
 inflated: e/r0.class
 inflated: e/s.class
 inflated: e/s0.class
 inflated: e/t.class
 inflated: e/t0.class
 inflated: e/u.class
 inflated: e/u0.class
 inflated: e/v.class
 inflated: e/v0.class
 inflated: e/w.class
 inflated: e/w0.class
 inflated: e/x.class
 inflated: e/x0.class
 inflated: e/y.class
 inflated: e/y0.class
 inflated: e/z.class
 inflated: e/z0.class
 inflated: f/a.class
 inflated: f/b.class
 inflated: f/c.class
 inflated: f/d.class
 inflated: g/a.class
 inflated: g/b.class
 inflated: g/c.class
 inflated: g/d.class
 inflated: g/e.class
 inflated: g/f.class
 inflated: g/g.class
 inflated: g/h.class
 inflated: g/i.class
 inflated: g/j.class
 inflated: g/k.class
 inflated: g/l.class
 inflated: g/m.class
 inflated: g/n.class
 inflated: g/o.class
 inflated: g/p.class
 inflated: g/q.class
 inflated: g/r.class
 inflated: g/s.class
 inflated: g/t.class
 inflated: g/u.class
 inflated: g/v.class
 inflated: g/w.class
 inflated: g/x.class
 inflated: g/y.class
 inflated: META-INF/NeuroID_androidLibRelease.kotlin_module
➜  "3.5.2" 

```