### PR TITLE
ENG-9865 proguard rule updates to keep react native extension classes

### DIFF
--- a/NeuroID/proguard-rules.pro
+++ b/NeuroID/proguard-rules.pro
@@ -59,3 +59,7 @@
 -keep interface com.neuroid.tracker.compose.JetpackCompose { *; }
 -keep class com.neuroid.tracker.NeuroID$Companion { *; }
 -keep class com.neuroid.tracker.NeuroID$Builder { *; }
+-keep class com.neuroid.tracker.extensions.** { *; }
+
+
+


### PR DESCRIPTION
SDK configuration needs extension classes un-obfuscated to enabled configuration in ReactNative apps. 


