### PR TITLE
reuqired for API34+ otherwise crash occurs, requries another release.

### DIFF
--- a/NeuroID/proguard-rules.pro
+++ b/NeuroID/proguard-rules.pro
@@ -61,5 +61,8 @@
 -keep class com.neuroid.tracker.NeuroID$Builder { *; }
 -keep class com.neuroid.tracker.extensions.** { *; }
 
+# required for API 34+.
+-keep class com.neuroid.tracker.NeuroIDPublic$DefaultImpls { *; }
+
 
 


### PR DESCRIPTION
proguard rule update to fix crasher on APi34 and above devices. 
