### PR TITLE
ENG-9942 add keep to stop obfuscation of the metadata

### DIFF
--- a/NeuroID/proguard-rules.pro
+++ b/NeuroID/proguard-rules.pro
@@ -56,6 +56,7 @@
 -keep class com.neuroid.tracker.events.** { *; }
 -keep interface com.neuroid.tracker.NeuroIDPublic { *; }
 -keep class com.neuroid.tracker.NeuroID { *; }
+-keep class com.neuroid.tracker.utils.NIDMetaData { *; }
 -keep interface com.neuroid.tracker.compose.JetpackCompose { *; }
 -keep class com.neuroid.tracker.NeuroID$Companion { *; }
 -keep class com.neuroid.tracker.NeuroID$Builder { *; }


### PR DESCRIPTION
Added keep rule to not obfuscate the metadata. 

metadata without the keep rule
`"metadata": {
        "a": "samsung",
        "b": "r11q",
        "c": "UP1A.231005.007.S711U1UES6CYC1",
        "d": "samsung",
        "e": "SM-S711U1",
        "f": "r11quew",
        "g": "34",
        "h": "1080,2218",
        "i": "Mint",
        "j": 7.051990509033203,
        "k": 100,
        "l": false,
        "m": true,
        "n": false,
        "o": {
          "authorizationStatus": "unknown",
          "latitude": -1.0,
          "longitude": -1.0
        },
        "p": 1746118723134
      }`

metadata with the keep rule: 
`"metadata":{"batteryLevel":100,"brand":"samsung","carrier":"Mint","device":"r11q","display":"UP1A.231005.007.S711U1UES6CYC1","displayResolution":"1080,2218","gpsCoordinates":{"authorizationStatus":"unknown","latitude":-1.0,"longitude":-1.0},"isJailBreak":false,"isSimulator":false,"isWifiOn":true,"lastInstallTime":1746118723134,"manufacturer":"samsung","model":"SM-S711U1","osVersion":"34","product":"r11quew","totalMemory":7.051990509033203}`