### PR TITLE
ENG-9964 restrict obfuscation on the domain name

### DIFF
--- a/NeuroID/proguard-rules.pro
+++ b/NeuroID/proguard-rules.pro
@@ -30,6 +30,7 @@
 #    public static int w(...);
 #}
 
+-keeppackagenames com.neuroid.**
 -keepattributes Signature
 -keepattributes *Annotation*
 


### PR DESCRIPTION
Do not obfuscate the domain name in method/class signatures. Example: 

`com.neuroid.example.EventModel`

obfuscate this to:

`com.neuroid.a.b`

Right now we are obfuscating to:

`a.b.c.d`

This will help in future integrations where our customers are running into name space collisions with other obfuscated libraries or their own libraries and not require elaborate exclude rules in build.gradle dependency lists. 