### PR TITLE
ENG-10127 FPJS id cache expiration pull from remote config

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -79,6 +79,8 @@ fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean) = runBlocking {
                         ),
                         this.clientID,
                         this.linkedSiteID ?: "",
+                        null,
+                        configService
                     )
                 getADVSignal(advancedDeviceIDManagerService, clientKey, this )?.join()
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt
@@ -24,4 +24,6 @@ data class NIDRemoteConfig(
     val sampleRate: Int = NIDConfigService.DEFAULT_SAMPLE_RATE,
     @SerializedName(value = "site_id")
     val siteID: String = "",
+    @SerializedName(value = "advanced_cookie_expires")
+    val advancedCookieExpiration: Int = 24,
 )

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
@@ -42,6 +42,7 @@ internal class AdvancedDeviceIDManager(
     private val linkedSiteID: String,
     // only for testing purposes, need to create in real time to pass NID Key
     private val fpjsClient: FingerprintJS? = null,
+    private val configService: ConfigService
 ) : AdvancedDeviceIDManagerService {
     companion object {
         internal val NID_RID = "NID_RID_KEY"
@@ -168,7 +169,7 @@ internal class AdvancedDeviceIDManager(
                                 mapOf(
                                     "key" to requestResponse.second,
                                     "exp" to
-                                        (24 * 60 * 60 * 1000) +
+                                        (configService.configCache.advancedCookieExpiration * 60 * 60 * 1000) +
                                         System.currentTimeMillis(), // 24
                                     // hours from now
                                 ),

--- a/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
@@ -290,6 +290,7 @@ class AdvancedDeviceIDManagerServiceTest {
                 "",
                 "",
                 mockedFPJSClient,
+                getMockedConfigService()
             )
 
         return mapOf(


### PR DESCRIPTION
Pull and set FPJS ID cache expiration time from remote config. May need backend change as well to send this data over if not already in the config. 

key is expected to be: advanced_cookie_expires and value is expected to be an int. 24hrs will be set as default

Remote config excerpt with advancedCookieExpiration: 
`NID remoteConfig: NIDRemoteConfig(callInProgress=true, eventQueueFlushInterval=5, eventQueueFlushSize=2000, geoLocation=false, gyroAccelCadence=false, gyroAccelCadenceTime=200, requestTimeout=10, linkedSiteOptions={form_parks912=NIDLinkedSiteOption(sampleRate=50), form_bench881=NIDLinkedSiteOption(sampleRate=0), form_hares612=NIDLinkedSiteOption(sampleRate=100)}, sampleRate=100, siteID=form_skein469, advancedCookieExpiration=24)`