### PR TITLE
ENG-10213 allow user to pass in FPJS key through configuration. move …

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -79,6 +79,7 @@ class NeuroID
         internal var clientKey: String,
         internal var isAdvancedDevice: Boolean,
         serverEnvironment: String = PRODUCTION,
+        internal var fpjsKey: String? = null
     ) : NeuroIDPublic {
         @Volatile internal var pauseCollectionJob: Job? = null // internal only for testing purposes
 
@@ -184,6 +185,8 @@ class NeuroID
                     collectionTimeout = 10,
                     configTimeout = 10,
                 )
+
+            captureAdvancedDevice(isAdvancedDevice, fpjsKey)
 
             configService =
                 NIDConfigService(
@@ -321,6 +324,7 @@ class NeuroID
             val clientKey: String = "",
             val isAdvancedDevice: Boolean = false,
             val serverEnvironment: String = PRODUCTION,
+            val fpjsKey: String? = null
         ) {
             fun build() {
                 val neuroID =
@@ -329,6 +333,7 @@ class NeuroID
                         clientKey,
                         isAdvancedDevice,
                         serverEnvironment,
+                        fpjsKey
                     )
                 setNeuroIDInstance(neuroID)
             }
@@ -553,7 +558,7 @@ class NeuroID
         internal fun checkThenCaptureAdvancedDevice(shouldCapture: Boolean = isAdvancedDevice,
                                                     dispatcher: CoroutineDispatcher = Dispatchers.IO) {
             CoroutineScope(dispatcher).launch {
-                captureAdvancedDevice(shouldCapture)
+                captureAdvancedDevice(shouldCapture, fpjsKey)
             }
         }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -78,8 +78,9 @@ class NeuroID
         internal var application: Application?,
         internal var clientKey: String,
         internal var isAdvancedDevice: Boolean,
-        serverEnvironment: String = PRODUCTION,
-        internal var advancedDeviceKey: String? = null
+        internal var advancedDeviceKey: String? = null,
+        serverEnvironment: String = PRODUCTION
+
     ) : NeuroIDPublic {
         @Volatile internal var pauseCollectionJob: Job? = null // internal only for testing purposes
 
@@ -335,11 +336,10 @@ class NeuroID
                         application,
                         clientKey,
                         isAdvancedDevice,
-                        serverEnvironment,
-                        advancedDeviceKey
+                        advancedDeviceKey,
+                        serverEnvironment
                     )
                 setNeuroIDInstance(neuroID)
-                println("kurt_test calling build()")
             }
         }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -186,8 +186,6 @@ class NeuroID
                     configTimeout = 10,
                 )
 
-            captureAdvancedDevice(isAdvancedDevice, fpjsKey)
-
             configService =
                 NIDConfigService(
                     dispatcher,
@@ -219,6 +217,8 @@ class NeuroID
                         logger,
                         configService,
                     )
+
+                captureAdvancedDevice(isAdvancedDevice, fpjsKey)
 
                 sessionService =
                     NIDSessionService(

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -79,7 +79,7 @@ class NeuroID
         internal var clientKey: String,
         internal var isAdvancedDevice: Boolean,
         serverEnvironment: String = PRODUCTION,
-        internal var fpjsKey: String? = null
+        internal var advancedDeviceKey: String? = null
     ) : NeuroIDPublic {
         @Volatile internal var pauseCollectionJob: Job? = null // internal only for testing purposes
 
@@ -87,6 +87,7 @@ class NeuroID
         internal var sessionID = ""
         internal var clientID = ""
         internal var userID = ""
+
         internal var linkedSiteID: String? = null
         internal var packetNumber: Int = 0
         internal var tabID: String
@@ -218,7 +219,9 @@ class NeuroID
                         configService,
                     )
 
-                captureAdvancedDevice(isAdvancedDevice, fpjsKey)
+                if (isAdvancedDevice) {
+                    captureAdvancedDevice(isAdvancedDevice, advancedDeviceKey)
+                }
 
                 sessionService =
                     NIDSessionService(
@@ -323,8 +326,8 @@ class NeuroID
             val application: Application? = null,
             val clientKey: String = "",
             val isAdvancedDevice: Boolean = false,
-            val serverEnvironment: String = PRODUCTION,
-            val fpjsKey: String? = null
+            val advancedDeviceKey: String? = null,
+            val serverEnvironment: String = PRODUCTION
         ) {
             fun build() {
                 val neuroID =
@@ -333,9 +336,10 @@ class NeuroID
                         clientKey,
                         isAdvancedDevice,
                         serverEnvironment,
-                        fpjsKey
+                        advancedDeviceKey
                     )
                 setNeuroIDInstance(neuroID)
+                println("kurt_test calling build()")
             }
         }
 
@@ -558,7 +562,7 @@ class NeuroID
         internal fun checkThenCaptureAdvancedDevice(shouldCapture: Boolean = isAdvancedDevice,
                                                     dispatcher: CoroutineDispatcher = Dispatchers.IO) {
             CoroutineScope(dispatcher).launch {
-                captureAdvancedDevice(shouldCapture, fpjsKey)
+                captureAdvancedDevice(shouldCapture, advancedDeviceKey)
             }
         }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -62,7 +62,7 @@ fun NeuroIDPublic.startSession(
 }
 
 @Synchronized
-fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean, fpjsKey: String?) = runBlocking {
+fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean, advancedDeviceKey: String?) = runBlocking {
     captureEvent(type = LOG, m = "shouldCapture setting: $shouldCapture", level = "INFO")
     if (shouldCapture) {
         NeuroID.getInternalInstance()?.apply {
@@ -80,7 +80,7 @@ fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean, fpjsKey: String?) = ru
                         this.clientID,
                         this.linkedSiteID ?: "",
                         configService,
-                        fpjsKey
+                        advancedDeviceKey
                     )
                 getADVSignal(advancedDeviceIDManagerService, clientKey, this )?.join()
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -62,7 +62,7 @@ fun NeuroIDPublic.startSession(
 }
 
 @Synchronized
-fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean) = runBlocking {
+fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean, fpjsKey: String?) = runBlocking {
     captureEvent(type = LOG, m = "shouldCapture setting: $shouldCapture", level = "INFO")
     if (shouldCapture) {
         NeuroID.getInternalInstance()?.apply {
@@ -79,7 +79,8 @@ fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean) = runBlocking {
                         ),
                         this.clientID,
                         this.linkedSiteID ?: "",
-                        configService
+                        configService,
+                        fpjsKey
                     )
                 getADVSignal(advancedDeviceIDManagerService, clientKey, this )?.join()
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -237,7 +237,7 @@ data class NIDEventModel(
                 WINDOW_BLUR -> contextString = "meta=${this.metadata}"
                 WINDOW_FOCUS -> contextString = "meta=${this.metadata}"
                 CONTEXT_MENU -> contextString = "meta=${this.metadata}"
-                ADVANCED_DEVICE_REQUEST -> contextString = "rid=${this.rid}, c=${this.c}, l=${this.l}, ct=${this.ct}"
+                ADVANCED_DEVICE_REQUEST -> contextString = "rid=${this.rid}, c=${this.c}, l=${this.l}, ct=${this.ct}, m=${this.m}"
                 LOG -> contextString = "m=${this.m}, ts=${this.ts}, level=${this.level}"
                 NETWORK_STATE -> contextString = "iswifi=${this.isWifi}, isconnected=${this.isConnected}"
                 ATTEMPTED_LOGIN -> contextString = "uid=${this.uid}"

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
@@ -42,7 +42,7 @@ internal class AdvancedDeviceIDManager(
     private val clientID: String,
     private val linkedSiteID: String,
     private val configService: ConfigService,
-    private val fpjsKey: String? = null,
+    private val advancedDeviceKey: String? = null,
     // only for testing purposes, need to create in real time to pass NID Key
     private val fpjsClient: FingerprintJS? = null
 ) : AdvancedDeviceIDManagerService {
@@ -87,7 +87,7 @@ internal class AdvancedDeviceIDManager(
         return true
     }
 
-    fun getFPJSKey(clientKey: String): ADVKeyFunctionResponse? {
+    fun getAdvancedDeviceKey(clientKey: String): ADVKeyFunctionResponse? {
         val nidKeyResponse =
             advNetworkService.getNIDAdvancedDeviceAccessKey(clientKey, clientID, linkedSiteID)
 
@@ -122,8 +122,8 @@ internal class AdvancedDeviceIDManager(
         // check if we have a user entered FPJS key,
         // if not, get it from server
         var fpjsRetrievedKey = ""
-        if (fpjsKey.isNullOrEmpty()) {
-            val keyFunctionResponse = getFPJSKey(clientKey)
+        if (advancedDeviceKey.isNullOrEmpty()) {
+            val keyFunctionResponse = getAdvancedDeviceKey(clientKey)
             // if server gotten FPJS key is null or empty exit immediately
             if (keyFunctionResponse == null) {
                 return null
@@ -143,7 +143,7 @@ internal class AdvancedDeviceIDManager(
                 FingerprintJSFactory(applicationContext = context)
                     .createInstance(
                         Configuration(
-                            apiKey = if (!fpjsKey.isNullOrEmpty()) fpjsKey else fpjsRetrievedKey,
+                            apiKey = if (!advancedDeviceKey.isNullOrEmpty()) advancedDeviceKey else fpjsRetrievedKey,
                             endpointUrl = remoteUrl,
                         ),
                     )
@@ -179,7 +179,7 @@ internal class AdvancedDeviceIDManager(
                             l = stopTime - startTime,
                             // wifi/cell
                             ct = neuroID.networkConnectionType,
-                            m = if (fpjsKey.isNullOrEmpty()) "server retrieved FPJS key" else "user entered FPJS key"
+                            m = if (advancedDeviceKey.isNullOrEmpty()) "server retrieved FPJS key" else "user entered FPJS key"
                         )
 
                         logger.d(msg = "Caching Request ID: ${requestResponse.second}")

--- a/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
@@ -46,7 +46,7 @@ class AdvancedDeviceIDManagerServiceTest {
      */
     @Test
     fun testGetADVSignal_is_sampled_true() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetFPJSKey("")
+        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
         val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
         val mockedNIDSamplingService = mockk<NIDSamplingService>()
         every { mockedNIDSamplingService.isSessionFlowSampled() } returns true
@@ -58,7 +58,7 @@ class AdvancedDeviceIDManagerServiceTest {
 
     @Test
     fun testGetADVSignal_is_sampled_false() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetFPJSKey("")
+        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
         val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
         val mockedNIDSamplingService = mockk<NIDSamplingService>()
         every { mockedNIDSamplingService.isSessionFlowSampled() } returns false
@@ -71,7 +71,7 @@ class AdvancedDeviceIDManagerServiceTest {
     //    getCachedID
     @Test
     fun testGetCachedID_not_stored() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetFPJSKey("")
+        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
         val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
         val mockedSharedPreferences = mocks["mockedSharedPreferences"] as NIDSharedPrefsDefaults
 
@@ -85,7 +85,7 @@ class AdvancedDeviceIDManagerServiceTest {
 
     @Test
     fun testGetCachedID_default_value() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetFPJSKey()
+        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey()
         val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
         val mockedSharedPreferences = mocks["mockedSharedPreferences"] as NIDSharedPrefsDefaults
 
@@ -99,7 +99,7 @@ class AdvancedDeviceIDManagerServiceTest {
 
     @Test
     fun testGetCachedID_expired_id() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetFPJSKey("{\"key\":\"testingExp\", \"exp\":0}")
+        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("{\"key\":\"testingExp\", \"exp\":0}")
         val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
         val mockedSharedPreferences = mocks["mockedSharedPreferences"] as NIDSharedPrefsDefaults
 
@@ -115,7 +115,7 @@ class AdvancedDeviceIDManagerServiceTest {
     fun testGetCachedID_valid_cache() {
         val keyValue = "ValidKey"
         val mocks =
-            buildAdvancedDeviceIDManagerService_noUserSetFPJSKey(
+            buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey(
                 "{\"key\":\"$keyValue\", \"exp\":${System.currentTimeMillis() + (1 * 60 * 60 * 1000)}}",
             ) { e: NIDEventModel ->
                 assert(e.type == ADVANCED_DEVICE_REQUEST) { "Expected event type to be ${ADVANCED_DEVICE_REQUEST}, found ${e.type}" }
@@ -145,7 +145,7 @@ class AdvancedDeviceIDManagerServiceTest {
     fun testGetRemoteID_no_nid_response() {
         val errorMessage = "Network Error"
         val mocks =
-            buildAdvancedDeviceIDManagerService_noUserSetFPJSKey(
+            buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey(
                 networkServiceResult = Triple("", false, errorMessage),
             ) { e: NIDEventModel ->
                 assert(e.type == LOG) { "Expected event type to be $LOG, found ${e.type}" }
@@ -177,7 +177,7 @@ class AdvancedDeviceIDManagerServiceTest {
             "Reached maximum number of retries (${NIDAdvancedDeviceNetworkService.RETRY_COUNT}) to get Advanced Device Signal Request ID:$errorMessage"
 
         val mocks =
-            buildAdvancedDeviceIDManagerService_noUserSetFPJSKey(
+            buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey(
                 networkServiceResult = Triple("", true, ""),
                 fpjsResponse = Pair(null, errorMessage),
             ) { e: NIDEventModel ->
@@ -226,7 +226,7 @@ class AdvancedDeviceIDManagerServiceTest {
             val validRID = "Valid RID Key"
 
             val mocks =
-                buildAdvancedDeviceIDManagerService_noUserSetFPJSKey(
+                buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey(
                     networkServiceResult = Triple("", true, ""),
                     fpjsResponse = Pair(validRID, null),
                 ) { e: NIDEventModel ->
@@ -263,7 +263,7 @@ class AdvancedDeviceIDManagerServiceTest {
             val validRID = "Valid RID Key"
 
             val mocks =
-                buildAdvancedDeviceIDManagerService_userSetFPJSKey(
+                buildAdvancedDeviceIDManagerService_userSetAdvancedKey(
                     networkServiceResult = Triple("", true, ""),
                     fpjsResponse = Pair(validRID, null),
                 ) { e: NIDEventModel ->
@@ -297,11 +297,11 @@ class AdvancedDeviceIDManagerServiceTest {
     /*
         Mocking Functions
      */
-    private fun buildAdvancedDeviceIDManagerService_noUserSetFPJSKey(
+    private fun buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey(
         sharedPrefGetValue: String = "{\"key\":\"testingExp\", \"exp\":0}",
         networkServiceResult: Triple<String, Boolean, String> = Triple("", false, ""),
         fpjsResponse: Pair<String?, String?> = Pair(null, null),
-        fpjsKey: String? = null,
+        advancedDeviceKey: String? = null,
         saveEventTest: (e: NIDEventModel) -> Unit = {},
     ): Map<String, Any> {
         val mockedNeuroID = getMockedNeuroID()
@@ -327,7 +327,7 @@ class AdvancedDeviceIDManagerServiceTest {
                 "",
                 "",
                 getMockedConfigService(),
-                fpjsKey,
+                advancedDeviceKey,
                 mockedFPJSClient
             )
 
@@ -346,11 +346,11 @@ class AdvancedDeviceIDManagerServiceTest {
     /*
         Mocking Functions
      */
-    private fun buildAdvancedDeviceIDManagerService_userSetFPJSKey(
+    private fun buildAdvancedDeviceIDManagerService_userSetAdvancedKey(
         sharedPrefGetValue: String = "{\"key\":\"testingExp\", \"exp\":0}",
         networkServiceResult: Triple<String, Boolean, String> = Triple("", false, ""),
         fpjsResponse: Pair<String?, String?> = Pair(null, null),
-        fpjsKey: String? = "gsagasdgasdgsdg",
+        advancedDeviceKey: String? = "gsagasdgasdgsdg",
         saveEventTest: (e: NIDEventModel) -> Unit = {},
     ): Map<String, Any> {
         val mockedNeuroID = getMockedNeuroID()
@@ -376,7 +376,7 @@ class AdvancedDeviceIDManagerServiceTest {
                 "",
                 "",
                 getMockedConfigService(),
-                fpjsKey,
+                advancedDeviceKey,
                 mockedFPJSClient
             )
 


### PR DESCRIPTION
allow user to pass in FPJS key through configuration. 
move captureAdvancedDevice() up into SDK initialization.

If SDK is started with the fpjsKey parameter filled, the following Advanced Device Request will be fired (assuming it is successful)
```
NeuroID.Builder(
            this,
            "key_live_MwC5DQNYzRsRhnnYjvz1fJtp",
            isAdvancedDevice = true,
            fpjsKey = "<some_FPJS_key>",
            serverEnvironment = NeuroID.PRODUCTION
        ).build()
```
`EVENT: ADVANCED_DEVICE_REQUEST - null - rid=1750725928952.13nqwP, c=false, l=1910, ct=wifi, m=user entered FPJS key
`

If SDK is started without the fpjsKey parameter filled (or set empty), the following Advanced Device Request will be fired (assuming it is successful)
```
NeuroID.Builder(
            this,
            "key_live_MwC5DQNYzRsRhnnYjvz1fJtp",
            isAdvancedDevice = true,
            serverEnvironment = NeuroID.PRODUCTION
        ).build()
```
`EVENT: ADVANCED_DEVICE_REQUEST - null - rid=1750726348615.tAllF3, c=false, l=1543, ct=wifi, m=server retrieved FPJS key`

Looks like the call itself without the getting the key is taking roughly 1800ms as specified in the l param and confirmed in the instrumentation. 
```
2025-06-23 18:35:39.373 26154-26181 NeuroID Debug           com...roidsandboxapplayout.us.debug  D  Generating Request ID for Advanced Device Signals: 1750728937556.s6sS05
2025-06-23 18:35:39.375 26154-26181 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: ADVANCED_DEVICE_REQUEST - null - rid=1750728937556.s6sS05, c=false, l=1860, ct=wifi, m=user entered FPJS key
2025-06-23 18:35:39.375 26154-26181 NeuroID Debug           com...roidsandboxapplayout.us.debug  D  Caching Request ID: 1750728937556.s6sS05
2025-06-23 18:35:39.377 26154-26181 System.out              com...roidsandboxapplayout.us.debug  I  kurt_test ADV retrieval complete: 1863
```
