### PR TITLE
ENG-10215, pass ReactNative set advancedDeviceKey to native

### DIFF
--- a/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
+++ b/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
@@ -15,6 +15,7 @@ class NIDRNBuilder( val application: Application? = null,
         Log.d("NIDRNBuilder", "set options: $options")
         NeuroID.Builder(application, clientKey,
             options[RNConfigOptions.isAdvancedDevice] as Boolean,
+            options[RNConfigOptions.advancedDeviceKey] as String,
             options[RNConfigOptions.environment] as String).build()
         NeuroID.getInstance()?.setIsRN()
     }
@@ -28,9 +29,16 @@ class NIDRNBuilder( val application: Application? = null,
         // defaults
         var isAdvancedDevice = false
         var environment = NeuroID.PRODUCTION
+        var advancedDeviceKey = ""
 
         val options = mutableMapOf<RNConfigOptions, Any>()
         rnOptions?.let {rnOptionsMap ->
+            // set the advanced device key from the advancedDeviceKey option, default empty string
+            if (rnOptionsMap.hasKey(RNConfigOptions.advancedDeviceKey.name)) {
+                rnOptionsMap.getString(RNConfigOptions.advancedDeviceKey.name)?.let {
+                    advancedDeviceKey = it
+                }
+            }
             // set the is advanced flag true or false from isAdvancedDevice option, default false
             if (rnOptionsMap.hasKey(RNConfigOptions.isAdvancedDevice.name)) {
                 rnOptionsMap.getBoolean(RNConfigOptions.isAdvancedDevice.name).let {
@@ -52,11 +60,13 @@ class NIDRNBuilder( val application: Application? = null,
         }
         options[RNConfigOptions.environment] = environment
         options[RNConfigOptions.isAdvancedDevice] = isAdvancedDevice
+        options[RNConfigOptions.advancedDeviceKey] = advancedDeviceKey
         return options
     }
 }
 
 enum class RNConfigOptions {
     isAdvancedDevice,
-    environment
+    environment,
+    advancedDeviceKey
 }

--- a/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
+++ b/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
@@ -18,6 +18,7 @@ class NIDRNBuilderTest {
         println(mapOptions)
         assert(!(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean))
         assert((mapOptions[RNConfigOptions.environment] as String) == NeuroID.PRODUCTION)
+        assert((mapOptions[RNConfigOptions.advancedDeviceKey] as String) == "")
     }
 
     @Test
@@ -26,13 +27,16 @@ class NIDRNBuilderTest {
         val options = mockk<ReadableMap>()
         every {options.hasKey(RNConfigOptions.isAdvancedDevice.name)} returns true
         every {options.hasKey(RNConfigOptions.environment.name)} returns true
+        every {options.hasKey(RNConfigOptions.advancedDeviceKey.name)} returns true
         every {options.getBoolean(RNConfigOptions.isAdvancedDevice.name)} returns true
+        every {options.getString(RNConfigOptions.advancedDeviceKey.name)} returns "testkey"
         every {options.getString(RNConfigOptions.environment.name)} returns NeuroID.PRODSCRIPT_DEVCOLLECTION
         val t = NIDRNBuilder(mockApp, "dummy_key", options)
         val mapOptions = t.parseOptions(options)
         println(mapOptions)
         assert((mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean))
         assert((mapOptions[RNConfigOptions.environment] as String) == NeuroID.PRODSCRIPT_DEVCOLLECTION)
+        assert((mapOptions[RNConfigOptions.advancedDeviceKey] as String) == "testkey")
     }
 
     @Test
@@ -43,5 +47,6 @@ class NIDRNBuilderTest {
         println(mapOptions)
         assert(!(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean))
         assert((mapOptions[RNConfigOptions.environment] as String) == NeuroID.PRODUCTION)
+        assert((mapOptions[RNConfigOptions.advancedDeviceKey] as String) == "")
     }
 }


### PR DESCRIPTION
 Pass ReactNative set advancedDeviceKey to the native NeuroID configuration. 