### PR TITLE
ENG-10458 add throttling to touch events per DS suggestion.

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/events/TouchEventManager.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/events/TouchEventManager.kt
@@ -12,6 +12,7 @@ import com.neuroid.tracker.extensions.getIdOrTag
 import com.neuroid.tracker.models.NIDTouchModel
 import com.neuroid.tracker.utils.NIDLog
 import com.neuroid.tracker.utils.NIDLogWrapper
+import com.neuroid.tracker.utils.NIDTime
 import com.neuroid.tracker.utils.detectViewType
 import com.neuroid.tracker.utils.getEtnSenderName
 
@@ -19,10 +20,18 @@ class TouchEventManager(
     private val viewParent: ViewGroup,
     internal val neuroID: NeuroID,
     internal val logger: NIDLogWrapper,
+    private val nidTime: NIDTime = NIDTime()
 ) {
     private var lastView: View? = null
     private var lastViewName = ""
     private var lastTypeOfView = 0
+    internal var lastTouchMoveIntervalStart = 0L //milliseconds
+    internal var missCounter = 0
+    internal var hitCounter = 0
+
+    companion object {
+        const val LAST_TOUCH_MOVE_WAIT_INTERVAL = 50
+    }
 
     fun detectView(
         motionEvent: MotionEvent?,
@@ -76,26 +85,31 @@ class TouchEventManager(
             var eventType = ""
             when (it.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    if (typeOfView > 0) {
-                        lastViewName = nameView
-                        lastTypeOfView = typeOfView
+                    lastViewName = nameView
+                    lastTypeOfView = typeOfView
 
-                        shouldSaveEvent = true
-                        eventType = TOUCH_START
-                    }
+                    shouldSaveEvent = true
+                    eventType = TOUCH_START
+                    // reset interval timer so we always catch first touch move
+                    lastTouchMoveIntervalStart = 0
+                    missCounter = 0
+                    hitCounter = 0
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    shouldSaveEvent = true
-                    eventType = TOUCH_MOVE
+                    if (!shouldRecordMoveEvent()) {
+                        shouldSaveEvent = false
+                        eventType = ""
+                    } else {
+                        shouldSaveEvent = true
+                        eventType = TOUCH_MOVE
+                    }
                 }
                 MotionEvent.ACTION_UP -> {
-                    if (lastTypeOfView > 0) {
-                        lastTypeOfView = 0
-                        lastViewName = ""
+                    lastTypeOfView = 0
+                    lastViewName = ""
 
-                        shouldSaveEvent = true
-                        eventType = TOUCH_END
-                    }
+                    shouldSaveEvent = true
+                    eventType = TOUCH_END
                 }
             }
 
@@ -112,10 +126,23 @@ class TouchEventManager(
                     touches = listOf(NIDTouchModel(0f, it.x, it.y)),
                     v = v,
                     attrs = attrJSON,
+                    m = if (eventType == TOUCH_END) "events_logged=$hitCounter events_not_logged=$missCounter" else ""
                 )
             }
 
             currentView
+        }
+    }
+
+    fun shouldRecordMoveEvent(): Boolean {
+        val timeDiff = (nidTime.getCurrentTimeMillis() - lastTouchMoveIntervalStart)
+        if (timeDiff <= LAST_TOUCH_MOVE_WAIT_INTERVAL) {
+            missCounter ++
+            return false
+        } else {
+            lastTouchMoveIntervalStart = nidTime.getCurrentTimeMillis()
+            hitCounter ++
+            return true
         }
     }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -223,7 +223,7 @@ data class NIDEventModel(
                         "et=${this.et}, rts=${this.rts}, ec=${this.ec} v=${this.v} tg=${this.tg} meta=${this.metadata} attrs=[${this.attrs}]"
                 "DEREGISTER_TARGET" -> contextString = ""
                 TOUCH_START -> contextString = "xy=${this.touches} tg=${this.tg} tgs=${this.tgs} ec=${this.ec} syn=${this.synthetic}"
-                TOUCH_END -> contextString = "xy=${this.touches} tg=${this.tg} tgs=${this.tgs} ec=${this.ec} syn=${this.synthetic}"
+                TOUCH_END -> contextString = "xy=${this.touches} tg=${this.tg} tgs=${this.tgs} ec=${this.ec} syn=${this.synthetic} m=${this.m}"
                 TOUCH_MOVE -> contextString = "xy=${this.touches} tg=${this.tg} tgs=${this.tgs} ec=${this.ec} syn=${this.synthetic}"
                 CLOSE_SESSION -> contextString = ""
                 SET_VARIABLE -> contextString = this.v ?: ""

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTime.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/NIDTime.kt
@@ -1,0 +1,7 @@
+package com.neuroid.tracker.utils
+
+class NIDTime {
+    fun getCurrentTimeMillis(): Long {
+        return System.currentTimeMillis()
+    }
+}

--- a/NeuroID/src/test/java/com/neuroid/tracker/events/TouchEventManagerTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/events/TouchEventManagerTest.kt
@@ -1,0 +1,34 @@
+package com.neuroid.tracker.events
+
+import android.view.ViewGroup
+import com.neuroid.tracker.getMockedNeuroID
+import com.neuroid.tracker.utils.NIDLogWrapper
+import com.neuroid.tracker.utils.NIDTime
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+
+class TouchEventManagerTest {
+    @Test
+    fun testShouldLogMoveEvent() {
+        val mockNID = getMockedNeuroID()
+        val mockedViewGroup = mockk<ViewGroup>()
+        val mockedLogger = mockk<NIDLogWrapper>()
+        val mockedTime = mockk<NIDTime>()
+        every { mockedTime.getCurrentTimeMillis() } returns 50
+        val tem = TouchEventManager(mockedViewGroup, mockNID, mockedLogger, mockedTime)
+        assert(!tem.shouldRecordMoveEvent())
+        assert(tem.hitCounter == 0)
+        assert(tem.missCounter == 1)
+        every {mockedTime.getCurrentTimeMillis() } returns 51
+        assert(tem.shouldRecordMoveEvent())
+        assert(tem.hitCounter == 1)
+        assert(tem.missCounter == 1)
+        every {mockedTime.getCurrentTimeMillis() } returns 99
+        assert(!tem.shouldRecordMoveEvent())
+        assert(tem.hitCounter == 1)
+        assert(tem.missCounter == 2)
+    }
+
+
+}


### PR DESCRIPTION
Data Science noted that the Android app was sending way too many touch events. This PR will send touch move events every 50ms once a touch session is started (sampling every 2nd or 3rd touch event). The events will looks like this. 

``` 2025-08-18 22:58:16.368 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_START - main_view - xy=[NIDTouchModel(tid=0.0, x=379.0, y=1641.0)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.396 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=379.93475, y=1640.0652)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.461 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=476.91132, y=1625.0)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.527 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=686.0276, y=1655.106)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.593 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=729.9414, y=1757.6467)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.660 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=617.5682, y=1828.216)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.728 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=487.92673, y=1877.8147)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.793 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=397.91202, y=1844.0402)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.844 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=398.61517, y=1734.1761)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.911 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=544.3705, y=1657.0968)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:16.976 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=661.3616, y=1677.5424)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:17.043 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_MOVE - main_view - xy=[NIDTouchModel(tid=0.0, x=635.02045, y=1727.2474)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null
2025-08-18 22:58:17.080 19627-19627 NeuroID Debug Event     com...roidsandboxapplayout.us.debug  D  EVENT: TOUCH_END - main_view - xy=[NIDTouchModel(tid=0.0, x=570.0, y=1732.0)] tg={tgs=main_view, sender=, etn=} tgs=main_view ec=null syn=null m=events_logged=11 events_not_logged=32
```

on touch end in the message section, we send back the number of touches captured(events_logged) and touches not captured (events_not_logged). 

The start and end touches were not being sent back in previous versions. This PR will now send start and end touch sessions events.   

We should consider making this configurable later. 

