### PR TITLE
ENG-10392 pull config after job manager starts.

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -221,6 +221,8 @@ class NeuroID
                     clientKey,
                 )
 
+                configService.retrieveOrRefreshCache()
+
                 if (isAdvancedDevice) {
                     checkThenCaptureAdvancedDevice(isAdvancedDevice)
                 }


### PR DESCRIPTION
Pull remote configuration on SDK initialization after the job manager is started. 