### PR TITLE
ENG-10540 add coverage to sonar

### DIFF
--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -65,7 +65,9 @@ jobs:
 
       # Generate Jacoco coverage report
       - name: Jacoco Coverage
-        run: ./gradlew :NeuroID:jacocoTestReport
+        run: | 
+          ./gradlew :NeuroID:jacocoTestReport
+          cp NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml .
 
       # Upload coverage to SonarCloud
       - name: SonarQube Scan

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -76,6 +76,7 @@ jobs:
           cd jacoco
           ls
           cd jacocoTestReport
+          cd tests
           ls
           cp NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml .
 

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -72,6 +72,8 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@v5
         env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+            SONAR_PROJECT_KEY: 'NeuroID-neuroid-android'
+            SONAR_ORGANIZATION: 'neuroid'
 
   android_sdk_integration_test_layout_app:
     runs-on: [macos-13]

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -55,20 +55,19 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      # Execute unit test neuroid lib
-      - name: Unit Test NeuroId (android lib)
-        run: ./gradlew :NeuroID:testAndroidLibDebugUnitTest
+#      # Execute unit test neuroid lib
+#      - name: Unit Test NeuroId (android lib)
+#        run: ./gradlew :NeuroID:testAndroidLibDebugUnitTest
 
-      # Execute unit test neuroid reactnative lib
-      - name: Unit Test NeuroId (ReactNative)
-        run: ./gradlew :NeuroID:testReactNativeLibDebugUnitTest
+#      # Execute unit test neuroid reactnative lib
+#      - name: Unit Test NeuroId (ReactNative)
+#        run: ./gradlew :NeuroID:testReactNativeLibDebugUnitTest
 
       # Generate Jacoco coverage report
       - name: Jacoco Coverage
         run: | 
           ./gradlew :NeuroID:jacocoTestReport
           pwd
-          cd NeuroID/build/reports/jacoco/jacocoTestReport
           ls
           cp NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml .
 

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -69,6 +69,14 @@ jobs:
           ./gradlew :NeuroID:jacocoTestReport
           pwd
           ls
+          cd NeuroID
+          cd build
+          cd reports
+          ls
+          cd jacoco
+          ls
+          cd jacocoTestReport
+          ls
           cp NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml .
 
       # Upload coverage to SonarCloud

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -68,13 +68,6 @@ jobs:
         run: | 
           ./gradlew :NeuroID:jacocoTestReport
           pwd
-          ls
-          cd NeuroID
-          cd build
-          cd reports
-          ls
-          cd jacocoTestReport
-          ls
           cp NeuroID/build/reports/jacocoTestReport/jacoco.xml .
 
       # Upload coverage to SonarCloud

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -73,12 +73,9 @@ jobs:
           cd build
           cd reports
           ls
-          cd jacoco
-          ls
           cd jacocoTestReport
-          cd tests
           ls
-          cp NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml .
+          cp NeuroID/build/reports/jacocoTestReport/jacoco.xml .
 
       # Upload coverage to SonarCloud
       - name: SonarQube Scan

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Jacoco Coverage
         run: | 
           ./gradlew :NeuroID:jacocoTestReport
+          pwd
+          cd NeuroID/build/reports/jacoco/jacocoTestReport
+          ls
           cp NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml .
 
       # Upload coverage to SonarCloud

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -63,6 +63,16 @@ jobs:
       - name: Unit Test NeuroId (ReactNative)
         run: ./gradlew :NeuroID:testReactNativeLibDebugUnitTest
 
+      # Generate Jacoco coverage report
+      - name: Jacoco Coverage
+        run: ./gradlew :NeuroID:jacocoTestReport
+
+      # Upload coverage to SonarCloud
+      - name: SonarQube Scan
+        uses: SonarSource/sonarcloud-github-action@v5
+        env:
+            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   android_sdk_integration_test_layout_app:
     runs-on: [macos-13]
     steps:

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -55,19 +55,18 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-#      # Execute unit test neuroid lib
-#      - name: Unit Test NeuroId (android lib)
-#        run: ./gradlew :NeuroID:testAndroidLibDebugUnitTest
+      # Execute unit test neuroid lib
+      - name: Unit Test NeuroId (android lib)
+        run: ./gradlew :NeuroID:testAndroidLibDebugUnitTest
 
-#      # Execute unit test neuroid reactnative lib
-#      - name: Unit Test NeuroId (ReactNative)
-#        run: ./gradlew :NeuroID:testReactNativeLibDebugUnitTest
+      # Execute unit test neuroid reactnative lib
+      - name: Unit Test NeuroId (ReactNative)
+        run: ./gradlew :NeuroID:testReactNativeLibDebugUnitTest
 
       # Generate Jacoco coverage report
       - name: Jacoco Coverage
         run: | 
           ./gradlew :NeuroID:jacocoTestReport
-          pwd
           cp NeuroID/build/reports/jacocoTestReport/jacoco.xml .
 
       # Upload coverage to SonarCloud

--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -4,12 +4,21 @@ plugins {
     id 'kotlin-kapt'
     id 'maven-publish'
     id 'jacoco'
+    id 'org.sonarqube' version '6.3.1.5724'
 }
 def versionPropsFile = rootProject.file("version.properties")
 def versionProps = new Properties()
 if (versionPropsFile.exists()) {
     versionProps.load(new FileInputStream(versionPropsFile))
 }
+
+sonar {
+    properties {
+        property("sonar.projectKey", "Neuro-ID_neuroid-android-sdk")
+        property("sonar.host.url", "https://sonarcloud.io")
+    }
+}
+
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()
     exec {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -275,6 +275,11 @@ class NeuroID
             registrationIdentificationHelper = RegistrationIdentificationHelper(this, logger)
             nidActivityCallbacks = ActivityCallbacks(this, logger, registrationIdentificationHelper)
             nidComposeTextWatcher = NIDComposeTextWatcherUtils(this)
+
+            // testing coverage, remove after tests complete, do not merge
+            if (isAdvancedDevice) {
+                captureEvent(type = LOG, m = "Advanced Device Key: $advancedDeviceKey", level = "INFO")
+            }
         }
 
         fun incrementPacketNumber() {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -275,11 +275,6 @@ class NeuroID
             registrationIdentificationHelper = RegistrationIdentificationHelper(this, logger)
             nidActivityCallbacks = ActivityCallbacks(this, logger, registrationIdentificationHelper)
             nidComposeTextWatcher = NIDComposeTextWatcherUtils(this)
-
-            // testing coverage, remove after tests complete, do not merge
-            if (isAdvancedDevice) {
-                captureEvent(type = LOG, m = "Advanced Device Key: $advancedDeviceKey", level = "INFO")
-            }
         }
 
         fun incrementPacketNumber() {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+# Mandatory Parameters
+sonar.host.url=https://sonarcloud.io
+sonar.organization=neuro-id
+sonar.projectKey=Neuro-ID_neuroid-android-sdk

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.host.url=https://sonarcloud.io
 sonar.organization=neuro-id
 sonar.projectKey=Neuro-ID_neuroid-android-sdk
 
-sonar.sources=NeuroID/src
+sonar.sources=NeuroID/src/main/java/com/neuroid/tracker
 sonar.exclusions=**/R.java,**/BuildConfig.java,**/Manifest.java,**/*Test.java,**/test/**,**/androidTest/**
 sonar.tests=NeuroID/src/test/java
 sonar.coverage.jacoco.xmlReportPaths=jacoco.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,4 @@
 sonar.host.url=https://sonarcloud.io
 sonar.organization=neuro-id
 sonar.projectKey=Neuro-ID_neuroid-android-sdk
+sonar.coverage.jacoco.xmlReportPaths=NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@
 sonar.host.url=https://sonarcloud.io
 sonar.organization=neuro-id
 sonar.projectKey=Neuro-ID_neuroid-android-sdk
-sonar.coverage.jacoco.xmlReportPaths=NeuroID/build/reports/jacoco/jacocoTestReport/jacoco.xml
+sonar.coverage.jacoco.xmlReportPaths=jacoco.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.host.url=https://sonarcloud.io
 sonar.organization=neuro-id
 sonar.projectKey=Neuro-ID_neuroid-android-sdk
 
-sonar.sources=NeuroID/src/main/java
+sonar.sources=NeuroID/src
 sonar.exclusions=**/R.java,**/BuildConfig.java,**/Manifest.java,**/*Test.java,**/test/**,**/androidTest/**
 sonar.tests=NeuroID/src/test/java
 sonar.coverage.jacoco.xmlReportPaths=jacoco.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,5 @@ sonar.host.url=https://sonarcloud.io
 sonar.organization=neuro-id
 sonar.projectKey=Neuro-ID_neuroid-android-sdk
 sonar.coverage.jacoco.xmlReportPaths=jacoco.xml
+
+sonar.sources=NeuroID/src/main/java

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,8 @@
 sonar.host.url=https://sonarcloud.io
 sonar.organization=neuro-id
 sonar.projectKey=Neuro-ID_neuroid-android-sdk
-sonar.coverage.jacoco.xmlReportPaths=jacoco.xml
 
 sonar.sources=NeuroID/src/main/java
+sonar.exclusions=**/R.java,**/BuildConfig.java,**/Manifest.java,**/*Test.java,**/test/**,**/androidTest/**
+sonar.tests=NeuroID/src/test/java
+sonar.coverage.jacoco.xmlReportPaths=jacoco.xml


### PR DESCRIPTION
Make sure that coverage numbers show up in sonar. 

<img width="1776" height="768" alt="image" src="https://github.com/user-attachments/assets/ab099085-f225-4fc7-a0b3-66a6bf795cad" /> 

When code is added, the coverage numbers are calculated. Example, add this line to NeuroID.kt and sonar will report 60% coverage on the changed file. 

```
            // testing coverage, remove after tests complete, do not merge
            if (isAdvancedDevice) {
                captureEvent(type = LOG, m = "Advanced Device Key: $advancedDeviceKey", level = "INFO")
            }
```
