### PR TITLE
[ENG-11878] Deprecate `startAppFlow` and `attemptedLogin`

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -551,6 +551,7 @@ class NeuroID
             setupListeners()
         }
 
+        @Deprecated("attemptedLogin is deprecated and will be removed in a future release.")
         override fun attemptedLogin(attemptedRegisteredUserId: String?): Boolean {
             captureEvent(
                 type = LOG,
@@ -724,6 +725,7 @@ class NeuroID
         /**
          * ported from the iOS implementation
          */
+        @Deprecated("startAppFlow is deprecated and will be removed in a future release.")
         override fun startAppFlow(
             siteID: String,
             userID: String?,

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroIDPublic.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroIDPublic.kt
@@ -153,6 +153,7 @@ interface NeuroIDPublic {
      * This should be called when the user attempts to login. Returns true always. Returns false if
      * exception is thrown during the process.
      */
+    @Deprecated("attemptedLogin is deprecated and will be removed in a future release.")
     fun attemptedLogin(attemptedRegisteredUserId: String? = null): Boolean
 
     /**
@@ -165,6 +166,7 @@ interface NeuroIDPublic {
      * here for you with a user ID that is specified in the optional userID argument. If the
      * SDK is already started, the optional user id is not used and the SDK will not be restarted.
      */
+    @Deprecated("startAppFlow is deprecated and will be removed in a future release.")
     fun startAppFlow(
         siteID: String,
         userID: String? = null,


### PR DESCRIPTION
Deprecate `startAppFlow` and `attemptedLogin`.

[ENG-11878]

[ENG-11878]: https://neuro-id.atlassian.net/browse/ENG-11878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ