### PR TITLE
ENG-11313 add regional support to configuration

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -339,7 +339,7 @@ class NeuroID
                         nidConfiguration.advancedDeviceKey,
                         nidConfiguration.useAdvancedDeviceProxy,
                         nidConfiguration.serverEnvironment,
-                        region = nidConfiguration.region
+                        nidConfiguration.region
                     )
                 setNeuroIDInstance(neuroID)
             }
@@ -352,7 +352,7 @@ class NeuroID
             val isAdvancedDevice: Boolean = false,
             val advancedDeviceKey: String? = null,
             val serverEnvironment: String = PRODUCTION,
-            val region: String = "usWest"
+            val region: NIDRegion = NIDRegion.usWest
         ) {
             fun build() {
                 val neuroID =
@@ -363,7 +363,7 @@ class NeuroID
                         advancedDeviceKey,
                         useAdvancedDeviceProxy = true,
                         serverEnvironment,
-                        NIDRegion.valueOf(region)
+                        region
                     )
                 setNeuroIDInstance(neuroID)
             }
@@ -601,7 +601,10 @@ class NeuroID
         internal fun checkThenCaptureAdvancedDevice(shouldCapture: Boolean = isAdvancedDevice,
                                                     dispatcher: CoroutineDispatcher = Dispatchers.IO) {
             CoroutineScope(dispatcher).launch {
-                captureAdvancedDevice(shouldCapture, advancedDeviceKey, useAdvancedDeviceProxy)
+                captureAdvancedDevice(shouldCapture,
+                    advancedDeviceKey,
+                    useAdvancedDeviceProxy,
+                    region)
             }
         }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -11,6 +11,7 @@ import android.net.NetworkCapabilities
 import android.os.Build
 import android.view.View
 import androidx.annotation.VisibleForTesting
+import com.fingerprintjs.android.fpjs_pro.Configuration
 import com.neuroid.tracker.callbacks.ActivityCallbacks
 import com.neuroid.tracker.callbacks.NIDSensorHelper
 import com.neuroid.tracker.compose.JetpackComposeImpl
@@ -32,6 +33,7 @@ import com.neuroid.tracker.events.SET_VARIABLE
 import com.neuroid.tracker.extensions.captureAdvancedDevice
 import com.neuroid.tracker.models.NIDConfiguration
 import com.neuroid.tracker.models.NIDEventModel
+import com.neuroid.tracker.models.NIDRegion
 import com.neuroid.tracker.models.NIDSensorModel
 import com.neuroid.tracker.models.NIDTouchModel
 import com.neuroid.tracker.models.SessionStartResult
@@ -79,9 +81,10 @@ class NeuroID
         internal var isAdvancedDevice: Boolean,
         internal var advancedDeviceKey: String? = null,
         internal var useAdvancedDeviceProxy: Boolean = false,
-        internal var serverEnvironment: String = PRODUCTION
+        serverEnvironment: String = PRODUCTION,
+        internal var region: NIDRegion = NIDRegion.usWest
 
-    ) : NeuroIDPublic {
+        ) : NeuroIDPublic {
         @Volatile internal var pauseCollectionJob: Job? = null // internal only for testing purposes
 
         private var firstTime = true
@@ -144,7 +147,7 @@ class NeuroID
             when (serverEnvironment) {
                 PRODSCRIPT_DEVCOLLECTION -> {
                     endpoint = Constants.devEndpoint.displayName
-                    scriptEndpoint = Constants.productionScriptsEndpoint.displayName
+                    scriptEndpoint = region.productionScriptsEndpoint
                 }
                 DEVELOPMENT -> {
                     endpoint = Constants.devEndpoint.displayName
@@ -155,8 +158,8 @@ class NeuroID
                     scriptEndpoint = Constants.testScriptEndpoint.displayName
                 }
                 else -> {
-                    endpoint = Constants.productionEndpoint.displayName
-                    scriptEndpoint = Constants.productionScriptsEndpoint.displayName
+                    endpoint = region.productionEndpoint
+                    scriptEndpoint = region.productionScriptsEndpoint
                 }
             }
 
@@ -335,7 +338,8 @@ class NeuroID
                         nidConfiguration.isAdvancedDevice,
                         nidConfiguration.advancedDeviceKey,
                         nidConfiguration.useAdvancedDeviceProxy,
-                        nidConfiguration.serverEnvironment
+                        nidConfiguration.serverEnvironment,
+                        region = NIDRegion.valueOf(nidConfiguration.region)
                     )
                 setNeuroIDInstance(neuroID)
             }
@@ -347,7 +351,8 @@ class NeuroID
             val clientKey: String = "",
             val isAdvancedDevice: Boolean = false,
             val advancedDeviceKey: String? = null,
-            val serverEnvironment: String = PRODUCTION
+            val serverEnvironment: String = PRODUCTION,
+            val region: String = "usWest"
         ) {
             fun build() {
                 val neuroID =
@@ -357,7 +362,8 @@ class NeuroID
                         isAdvancedDevice,
                         advancedDeviceKey,
                         useAdvancedDeviceProxy = true,
-                        serverEnvironment
+                        serverEnvironment,
+                        NIDRegion.valueOf(region)
                     )
                 setNeuroIDInstance(neuroID)
             }
@@ -399,9 +405,8 @@ class NeuroID
             internal var isConnected = false
 
             internal var registeredViews: MutableSet<String> = mutableSetOf()
-
-            internal var endpoint = Constants.productionEndpoint.displayName
-            internal var scriptEndpoint = Constants.productionScriptsEndpoint.displayName
+            internal var endpoint = NIDRegion.usWest.productionEndpoint
+            internal var scriptEndpoint = NIDRegion.usWest.productionScriptsEndpoint
             private var singleton: NeuroID? = null
 
             @TestOnly
@@ -499,6 +504,13 @@ class NeuroID
         }
 
         @VisibleForTesting
+        /**
+         * testing will always uses usWest testing endpoints regardless of the region
+         * specified in the config since we don't
+         * want to have multiple testing endpoints in our tests.
+         * If we want to add more testing endpoints in the future we can
+         * add a parameter to specify which testing endpoint to use.
+         */
         override fun setTestingNeuroIDDevURL() {
             endpoint = Constants.devEndpoint.displayName
             scriptEndpoint = Constants.devScriptsEndpoint.displayName

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -339,7 +339,7 @@ class NeuroID
                         nidConfiguration.advancedDeviceKey,
                         nidConfiguration.useAdvancedDeviceProxy,
                         nidConfiguration.serverEnvironment,
-                        region = NIDRegion.valueOf(nidConfiguration.region)
+                        region = nidConfiguration.region
                     )
                 setNeuroIDInstance(neuroID)
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -3,12 +3,12 @@ package com.neuroid.tracker.extensions
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.NeuroIDPublic
 import com.neuroid.tracker.events.LOG
+import com.neuroid.tracker.models.NIDRegion
 import com.neuroid.tracker.models.SessionStartResult
 import com.neuroid.tracker.service.AdvancedDeviceIDManager
 import com.neuroid.tracker.service.AdvancedDeviceIDManagerService
 import com.neuroid.tracker.service.getADVNetworkService
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
-import com.neuroid.tracker.utils.Constants
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,8 +64,10 @@ fun NeuroIDPublic.startSession(
 }
 
 @Synchronized
-fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean, advancedDeviceKey: String?,
-                                  useAdvancedDeviceProxy: Boolean) = runBlocking {
+fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean,
+                                  advancedDeviceKey: String?,
+                                  useAdvancedDeviceProxy: Boolean,
+                                  region: NIDRegion = NIDRegion.usWest) = runBlocking {
     captureEvent(queuedEvent = true, type = LOG, m = "shouldCapture setting: $shouldCapture", level = "INFO")
     if (shouldCapture) {
         NeuroID.getInternalInstance()?.apply {
@@ -84,7 +86,8 @@ fun NeuroID.captureAdvancedDevice(shouldCapture: Boolean, advancedDeviceKey: Str
                         this.linkedSiteID ?: "",
                         configService,
                         advancedDeviceKey,
-                        useAdvancedDeviceProxy = useAdvancedDeviceProxy
+                        useAdvancedDeviceProxy = useAdvancedDeviceProxy,
+                        region = region
                     )
                 getADVSignal(advancedDeviceIDManagerService, clientKey, this)?.join()
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt
@@ -5,6 +5,6 @@ data class NIDConfiguration(val clientKey: String,
                             val isAdvancedDevice: Boolean,
                             val advancedDeviceKey: String? = null,
                             val useAdvancedDeviceProxy: Boolean = true,
-                            val serverEnvironment: String = "productionn",
+                            val serverEnvironment: String = "production",
                             val region: String = NIDRegion.usWest.name
 )

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt
@@ -1,7 +1,10 @@
 package com.neuroid.tracker.models
 
+
 data class NIDConfiguration(val clientKey: String,
                             val isAdvancedDevice: Boolean,
                             val advancedDeviceKey: String? = null,
                             val useAdvancedDeviceProxy: Boolean = true,
-                            val serverEnvironment: String = "production")
+                            val serverEnvironment: String = "productionn",
+                            val region: String = NIDRegion.usWest.name
+)

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt
@@ -6,5 +6,5 @@ data class NIDConfiguration(val clientKey: String,
                             val advancedDeviceKey: String? = null,
                             val useAdvancedDeviceProxy: Boolean = true,
                             val serverEnvironment: String = "production",
-                            val region: String = NIDRegion.usWest.name
+                            val region: NIDRegion = NIDRegion.usWest
 )

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
@@ -1,6 +1,6 @@
 package com.neuroid.tracker.models
 
-internal enum class NIDRegion(
+enum class NIDRegion(
     val fpjsProdDomain: String,
     val fpjsPrimaryDomain: String,
     val productionEndpoint: String,

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
@@ -10,5 +10,6 @@ enum class NIDRegion(
         fpjsProdDomain = "https://advanced.neuro-id.com",
         fpjsPrimaryDomain = "https://dn.neuroid.cloud/iynlfqcb0t",
         productionEndpoint = "https://receiver.neuroid.cloud/",
-        productionScriptsEndpoint = "https://scripts.neuro-id.com/")
+        productionScriptsEndpoint = "https://scripts.neuro-id.com/"
+    )
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
@@ -1,6 +1,6 @@
 package com.neuroid.tracker.models
 
-enum class NIDRegion(
+internal enum class NIDRegion(
     val fpjsProdDomain: String,
     val fpjsPrimaryDomain: String,
     val productionEndpoint: String,

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
@@ -1,0 +1,14 @@
+package com.neuroid.tracker.models
+
+enum class NIDRegion(
+    val fpjsProdDomain: String,
+    val fpjsPrimaryDomain: String,
+    val productionEndpoint: String,
+    val productionScriptsEndpoint: String) {
+
+    usWest(
+        fpjsProdDomain = "https://advanced.neuro-id.com",
+        fpjsPrimaryDomain = "https://dn.neuroid.cloud/iynlfqcb0t",
+        productionEndpoint = "https://receiver.neuroid.cloud/",
+        productionScriptsEndpoint = "https://scripts.neuro-id.com/")
+}

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
@@ -11,6 +11,7 @@ import com.neuroid.tracker.events.ADVANCED_DEVICE_REQUEST
 import com.neuroid.tracker.events.ADVANCED_DEVICE_REQUEST_FAILED
 import com.neuroid.tracker.events.LOG
 import com.neuroid.tracker.models.ADVKeyFunctionResponse
+import com.neuroid.tracker.models.NIDRegion
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
 import com.neuroid.tracker.utils.Constants
 import com.neuroid.tracker.utils.NIDLogWrapper
@@ -47,7 +48,8 @@ internal class AdvancedDeviceIDManager(
     // only for testing purposes, need to create in real time to pass NID Key
     private val fpjsClient: FingerprintJS? = null,
     private val useAdvancedDeviceProxy: Boolean,
-    val nidTime: NIDTime = NIDTime()
+    val nidTime: NIDTime = NIDTime(),
+    private val region: NIDRegion = NIDRegion.usWest
 ) : AdvancedDeviceIDManagerService {
     companion object {
         internal val NID_RID = "NID_RID_KEY"
@@ -114,9 +116,9 @@ internal class AdvancedDeviceIDManager(
 
     internal fun chooseUrl(useAdvancedDeviceProxy: Boolean) =
         if (useAdvancedDeviceProxy) {
-            Constants.fpjsPrimaryDomain.displayName
+            region.fpjsPrimaryDomain
         } else {
-            Constants.fpjsProdDomain.displayName
+            region.fpjsProdDomain
         }
 
     override fun getRemoteID(
@@ -150,7 +152,7 @@ internal class AdvancedDeviceIDManager(
                         Configuration(
                             apiKey = if (!advancedDeviceKey.isNullOrEmpty()) advancedDeviceKey else fpjsRetrievedKey,
                             endpointUrl = chooseUrl(useAdvancedDeviceProxy),
-                            fallbackEndpointUrls = arrayListOf(Constants.fpjsProdDomain.displayName)
+                            fallbackEndpointUrls = arrayListOf(region.fpjsProdDomain)
                         ),
                     )
             }

--- a/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/utils/Constants.kt
@@ -7,10 +7,6 @@ enum class Constants(val displayName: String) {
     integrationHealthAssetsFolder("integrationHealth"),
 
     debugEventTag("Event"),
-    fpjsProdDomain("https://advanced.neuro-id.com"),
-    fpjsPrimaryDomain("https://dn.neuroid.cloud/iynlfqcb0t"),
-    productionEndpoint("https://receiver.neuroid.cloud/"),
-    productionScriptsEndpoint("https://scripts.neuro-id.com/"),
     devEndpoint("https://receiver.neuro-dev.com/"),
     devScriptsEndpoint("https://scripts.neuro-dev.com/"),
     testScriptEndpoint("http://127.0.0.1:8000/")

--- a/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
+++ b/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
@@ -75,7 +75,7 @@ class NIDRNBuilder( val application: Application? = null,
                         NeuroID.PRODSCRIPT_DEVCOLLECTION -> environment =
                             NeuroID.PRODSCRIPT_DEVCOLLECTION
 
-                        NeuroID.DEVELOPMENT -> NeuroID.DEVELOPMENT
+                        NeuroID.DEVELOPMENT -> environment = NeuroID.DEVELOPMENT
                         else -> environment = NeuroID.PRODUCTION
                     }
                 }
@@ -89,13 +89,13 @@ class NIDRNBuilder( val application: Application? = null,
                     }
                 }
             }
-            options[RNConfigOptions.environment] = environment
-            options[RNConfigOptions.isAdvancedDevice] = isAdvancedDevice
-            options[RNConfigOptions.advancedDeviceKey] = advancedDeviceKey
-            options[RNConfigOptions.useAdvancedDeviceProxy] = useAdvancedDeviceProxy
-            options[RNConfigOptions.rnVersion] = rnVersion
-            options[RNConfigOptions.region] = region
         }
+        options[RNConfigOptions.environment] = environment
+        options[RNConfigOptions.isAdvancedDevice] = isAdvancedDevice
+        options[RNConfigOptions.advancedDeviceKey] = advancedDeviceKey
+        options[RNConfigOptions.useAdvancedDeviceProxy] = useAdvancedDeviceProxy
+        options[RNConfigOptions.rnVersion] = rnVersion
+        options[RNConfigOptions.region] = region
         return options
     }
 }

--- a/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
+++ b/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
@@ -21,7 +21,7 @@ class NIDRNBuilder( val application: Application? = null,
                 advancedDeviceKey = options[RNConfigOptions.advancedDeviceKey] as String,
                 useAdvancedDeviceProxy = options[RNConfigOptions.useAdvancedDeviceProxy] as Boolean,
                 serverEnvironment = options[RNConfigOptions.environment] as String,
-                region = options[RNConfigOptions.region] as String
+                region = NIDRegion.valueOf(options[RNConfigOptions.region] as String)
             ),
         ).build()
 

--- a/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
+++ b/NeuroID/src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt
@@ -6,6 +6,7 @@ import androidx.annotation.VisibleForTesting
 import com.facebook.react.bridge.ReadableMap
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.models.NIDConfiguration
+import com.neuroid.tracker.models.NIDRegion
 
 class NIDRNBuilder( val application: Application? = null,
                     val clientKey: String = "",
@@ -13,19 +14,23 @@ class NIDRNBuilder( val application: Application? = null,
     fun build() {
         val options = parseOptions(rnOptions)
         Log.d("NIDRNBuilder", "set options: $options")
-        NeuroID.BuilderConfig(application, NIDConfiguration(
-            clientKey = clientKey,
-            isAdvancedDevice = options[RNConfigOptions.isAdvancedDevice] as Boolean,
-            advancedDeviceKey = options[RNConfigOptions.advancedDeviceKey] as String,
-            useAdvancedDeviceProxy = options[RNConfigOptions.useAdvancedDeviceProxy] as Boolean,
-            serverEnvironment = options[RNConfigOptions.environment] as String)).build()
+        NeuroID.BuilderConfig(
+            application, NIDConfiguration(
+                clientKey = clientKey,
+                isAdvancedDevice = options[RNConfigOptions.isAdvancedDevice] as Boolean,
+                advancedDeviceKey = options[RNConfigOptions.advancedDeviceKey] as String,
+                useAdvancedDeviceProxy = options[RNConfigOptions.useAdvancedDeviceProxy] as Boolean,
+                serverEnvironment = options[RNConfigOptions.environment] as String,
+                region = options[RNConfigOptions.region] as String
+            ),
+        ).build()
 
         NeuroID.getInternalInstance()?.setIsRN(options[RNConfigOptions.rnVersion] as String)
     }
 
     /**
      * Returns a guaranteed map of options (environment and isAdvancedDevice) that we can use
-     * to configure NeuroID properly
+     * to configure NeuroID properly.
      */
     @VisibleForTesting
     internal fun parseOptions(rnOptions: ReadableMap?): Map<RNConfigOptions, Any> {
@@ -35,9 +40,10 @@ class NIDRNBuilder( val application: Application? = null,
         var advancedDeviceKey = ""
         var useAdvancedDeviceProxy = true
         var rnVersion = ""
+        var region = NIDRegion.usWest.name
 
         val options = mutableMapOf<RNConfigOptions, Any>()
-        rnOptions?.let {rnOptionsMap ->
+        rnOptions?.let { rnOptionsMap ->
             // set the advanced device key from the advancedDeviceKey option, default empty string
             if (rnOptionsMap.hasKey(RNConfigOptions.advancedDeviceKey.name)) {
                 rnOptionsMap.getString(RNConfigOptions.advancedDeviceKey.name)?.let {
@@ -74,13 +80,22 @@ class NIDRNBuilder( val application: Application? = null,
                     }
                 }
             }
+            // add more regions here, default to usWest for now since that's the only region we have
+            if (rnOptionsMap.hasKey(RNConfigOptions.region.name)) {
+                rnOptionsMap.getString(RNConfigOptions.region.name)?.let {
+                    when (it) {
+                        NIDRegion.usWest.name -> region = NIDRegion.usWest.name
+                        else -> region = NIDRegion.usWest.name
+                    }
+                }
+            }
+            options[RNConfigOptions.environment] = environment
+            options[RNConfigOptions.isAdvancedDevice] = isAdvancedDevice
+            options[RNConfigOptions.advancedDeviceKey] = advancedDeviceKey
+            options[RNConfigOptions.useAdvancedDeviceProxy] = useAdvancedDeviceProxy
+            options[RNConfigOptions.rnVersion] = rnVersion
+            options[RNConfigOptions.region] = region
         }
-        options[RNConfigOptions.environment] = environment
-        options[RNConfigOptions.isAdvancedDevice] = isAdvancedDevice
-        options[RNConfigOptions.advancedDeviceKey] = advancedDeviceKey
-        options[RNConfigOptions.useAdvancedDeviceProxy] = useAdvancedDeviceProxy
-        options[RNConfigOptions.rnVersion] = rnVersion
-
         return options
     }
 }
@@ -90,5 +105,6 @@ enum class RNConfigOptions {
     environment,
     advancedDeviceKey,
     useAdvancedDeviceProxy,
-    rnVersion
+    rnVersion,
+    region
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -17,6 +17,7 @@ import com.neuroid.tracker.utils.NIDBuildConfigWrapper
 import com.neuroid.tracker.utils.NIDVersion
 import com.neuroid.tracker.models.NIDConfiguration
 import com.neuroid.tracker.models.NIDEventModel
+import com.neuroid.tracker.models.NIDRegion
 import com.neuroid.tracker.service.NIDJobServiceManager
 import com.neuroid.tracker.service.NIDCallActivityListener
 import com.neuroid.tracker.service.NIDSessionService
@@ -300,8 +301,8 @@ open class NeuroIDClassUnitTests {
             NIDConfiguration("key_test_fake1234", false, "", true, NeuroID.PRODUCTION)
         ).build()
 
-        assertEquals(Constants.productionEndpoint.displayName, NeuroID.endpoint)
-        assertEquals(Constants.productionScriptsEndpoint.displayName, NeuroID.scriptEndpoint)
+        assertEquals(NIDRegion.usWest.productionEndpoint, NeuroID.endpoint)
+        assertEquals(NIDRegion.usWest.productionScriptsEndpoint, NeuroID.scriptEndpoint)
     }
 
     @Test
@@ -340,7 +341,42 @@ open class NeuroIDClassUnitTests {
         ).build()
 
         assertEquals(Constants.devEndpoint.displayName, NeuroID.endpoint)
-        assertEquals(Constants.productionScriptsEndpoint.displayName, NeuroID.scriptEndpoint)
+        assertEquals(NIDRegion.usWest.productionScriptsEndpoint, NeuroID.scriptEndpoint)
+    }
+
+    @Test
+    fun test_init_builderConfig_explicit_region_setsRegionAndProductionEndpoints() {
+        NeuroID._isSDKStarted = false
+        NeuroID.setSingletonNull()
+        NeuroID.BuilderConfig(
+            null,
+            NIDConfiguration(
+                clientKey = "key_test_fake1234",
+                isAdvancedDevice = false,
+                serverEnvironment = NeuroID.PRODUCTION,
+                region = NIDRegion.usWest.name,
+            )
+        ).build()
+
+        val instance = NeuroID.getInternalInstance()
+        assertEquals(NIDRegion.usWest, instance?.region)
+        assertEquals(NIDRegion.usWest.productionEndpoint, NeuroID.endpoint)
+        assertEquals(NIDRegion.usWest.productionScriptsEndpoint, NeuroID.scriptEndpoint)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun test_init_builderConfig_invalid_region_throws() {
+        NeuroID._isSDKStarted = false
+        NeuroID.setSingletonNull()
+        NeuroID.BuilderConfig(
+            null,
+            NIDConfiguration(
+                clientKey = "key_test_fake1234",
+                isAdvancedDevice = false,
+                serverEnvironment = NeuroID.PRODUCTION,
+                region = "invalid-region",
+            )
+        ).build()
     }
 
     @Test

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -354,7 +354,7 @@ open class NeuroIDClassUnitTests {
                 clientKey = "key_test_fake1234",
                 isAdvancedDevice = false,
                 serverEnvironment = NeuroID.PRODUCTION,
-                region = NIDRegion.usWest.name,
+                region = NIDRegion.usWest,
             )
         ).build()
 
@@ -362,21 +362,6 @@ open class NeuroIDClassUnitTests {
         assertEquals(NIDRegion.usWest, instance?.region)
         assertEquals(NIDRegion.usWest.productionEndpoint, NeuroID.endpoint)
         assertEquals(NIDRegion.usWest.productionScriptsEndpoint, NeuroID.scriptEndpoint)
-    }
-
-    @Test(expected = IllegalArgumentException::class)
-    fun test_init_builderConfig_invalid_region_throws() {
-        NeuroID._isSDKStarted = false
-        NeuroID.setSingletonNull()
-        NeuroID.BuilderConfig(
-            null,
-            NIDConfiguration(
-                clientKey = "key_test_fake1234",
-                isAdvancedDevice = false,
-                serverEnvironment = NeuroID.PRODUCTION,
-                region = "invalid-region",
-            )
-        ).build()
     }
 
     @Test

--- a/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
+++ b/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
@@ -56,16 +56,28 @@ class NIDRNBuilderTest {
     @Test
     fun testRNOption_environment_null_options() {
         val mockApp = mockk<Application>()
-        val options = mockk<ReadableMap>()
-        every {options.hasKey(any())} returns false
-        val t = NIDRNBuilder(mockApp, "dummy_key", options)
-        val mapOptions = t.parseOptions(options)
+        val t = NIDRNBuilder(mockApp, "dummy_key", null)
+        val mapOptions = t.parseOptions(null)
         assertFalse(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean)
         assertEquals(NeuroID.PRODUCTION, mapOptions[RNConfigOptions.environment] as String)
         assertEquals("", mapOptions[RNConfigOptions.advancedDeviceKey] as String)
         assertTrue(mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean)
         assertEquals("", mapOptions[RNConfigOptions.rnVersion] as String)
         assertEquals(NIDRegion.usWest.name, mapOptions[RNConfigOptions.region] as String)
+    }
+
+    @Test
+    fun testRNOption_environment_development_option_set() {
+        val mockApp = mockk<Application>()
+        val options = mockk<ReadableMap>()
+        every { options.hasKey(any()) } returns false
+        every { options.hasKey(RNConfigOptions.environment.name) } returns true
+        every { options.getString(RNConfigOptions.environment.name) } returns NeuroID.DEVELOPMENT
+
+        val t = NIDRNBuilder(mockApp, "dummy_key", options)
+        val mapOptions = t.parseOptions(options)
+
+        assertEquals(NeuroID.DEVELOPMENT, mapOptions[RNConfigOptions.environment] as String)
     }
 
     @Test

--- a/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
+++ b/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
@@ -3,8 +3,12 @@ package com.neuroid.tracker.extensions
 import android.app.Application
 import com.facebook.react.bridge.ReadableMap
 import com.neuroid.tracker.NeuroID
+import com.neuroid.tracker.models.NIDRegion
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NIDRNBuilderTest {
@@ -15,12 +19,12 @@ class NIDRNBuilderTest {
         every {options.hasKey(any())} returns false
         val t = NIDRNBuilder(mockApp, "dummy_key", options)
         val mapOptions = t.parseOptions(options)
-        println(mapOptions)
-        assert(!(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean))
-        assert((mapOptions[RNConfigOptions.environment] as String) == NeuroID.PRODUCTION)
-        assert((mapOptions[RNConfigOptions.advancedDeviceKey] as String) == "")
-        assert((mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean))
-        assert((mapOptions[RNConfigOptions.rnVersion] as String) == "")
+        assertFalse(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean)
+        assertEquals(NeuroID.PRODUCTION, mapOptions[RNConfigOptions.environment] as String)
+        assertEquals("", mapOptions[RNConfigOptions.advancedDeviceKey] as String)
+        assertTrue(mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean)
+        assertEquals("", mapOptions[RNConfigOptions.rnVersion] as String)
+        assertEquals(NIDRegion.usWest.name, mapOptions[RNConfigOptions.region] as String)
     }
 
     @Test
@@ -32,31 +36,50 @@ class NIDRNBuilderTest {
         every {options.hasKey(RNConfigOptions.advancedDeviceKey.name)} returns true
         every {options.hasKey(RNConfigOptions.useAdvancedDeviceProxy.name)} returns true
         every {options.hasKey( RNConfigOptions.rnVersion.name)} returns true
+        every {options.hasKey(RNConfigOptions.region.name)} returns true
         every {options.getBoolean(RNConfigOptions.isAdvancedDevice.name)} returns true
         every {options.getString(RNConfigOptions.advancedDeviceKey.name)} returns "testkey"
         every {options.getBoolean(RNConfigOptions.useAdvancedDeviceProxy.name)} returns false
         every {options.getString(RNConfigOptions.environment.name)} returns NeuroID.PRODSCRIPT_DEVCOLLECTION
         every {options.getString(RNConfigOptions.rnVersion.name)} returns "0.71.0"
+        every {options.getString(RNConfigOptions.region.name)} returns NIDRegion.usWest.name
         val t = NIDRNBuilder(mockApp, "dummy_key", options)
         val mapOptions = t.parseOptions(options)
-        println(mapOptions)
-        assert((mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean))
-        assert((mapOptions[RNConfigOptions.environment] as String) == NeuroID.PRODSCRIPT_DEVCOLLECTION)
-        assert((mapOptions[RNConfigOptions.advancedDeviceKey] as String) == "testkey")
-        assert(!(mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean))
-        assert(mapOptions[RNConfigOptions.rnVersion] as String == "0.71.0")
+        assertTrue(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean)
+        assertEquals(NeuroID.PRODSCRIPT_DEVCOLLECTION, mapOptions[RNConfigOptions.environment] as String)
+        assertEquals("testkey", mapOptions[RNConfigOptions.advancedDeviceKey] as String)
+        assertFalse(mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean)
+        assertEquals("0.71.0", mapOptions[RNConfigOptions.rnVersion] as String)
+        assertEquals(NIDRegion.usWest.name, mapOptions[RNConfigOptions.region] as String)
     }
 
     @Test
     fun testRNOption_environment_null_options() {
         val mockApp = mockk<Application>()
-        val t = NIDRNBuilder(mockApp, "dummy_key", null)
-        val mapOptions = t.parseOptions(null)
-        println(mapOptions)
-        assert(!(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean))
-        assert((mapOptions[RNConfigOptions.environment] as String) == NeuroID.PRODUCTION)
-        assert((mapOptions[RNConfigOptions.advancedDeviceKey] as String) == "")
-        assert((mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean))
-        assert((mapOptions[RNConfigOptions.rnVersion] as String) == "")
+        val options = mockk<ReadableMap>()
+        every {options.hasKey(any())} returns false
+        val t = NIDRNBuilder(mockApp, "dummy_key", options)
+        val mapOptions = t.parseOptions(options)
+        assertFalse(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean)
+        assertEquals(NeuroID.PRODUCTION, mapOptions[RNConfigOptions.environment] as String)
+        assertEquals("", mapOptions[RNConfigOptions.advancedDeviceKey] as String)
+        assertTrue(mapOptions[RNConfigOptions.useAdvancedDeviceProxy] as Boolean)
+        assertEquals("", mapOptions[RNConfigOptions.rnVersion] as String)
+        assertEquals(NIDRegion.usWest.name, mapOptions[RNConfigOptions.region] as String)
+    }
+
+    @Test
+    fun testRNOption_invalid_region_falls_back_to_usWest() {
+        val mockApp = mockk<Application>()
+        val options = mockk<ReadableMap>()
+        every { options.hasKey(any()) } returns false
+        every { options.hasKey(RNConfigOptions.region.name) } returns true
+        every { options.getString(RNConfigOptions.region.name) } returns "invalid-region"
+
+        val t = NIDRNBuilder(mockApp, "dummy_key", options)
+        val mapOptions = t.parseOptions(options)
+
+        assertEquals(NIDRegion.usWest.name, mapOptions[RNConfigOptions.region] as String)
     }
 }
+


### PR DESCRIPTION
Region support for the Android SDK:

Add new regions in the NIDRegions Enumeration here: 
```
enum class NIDRegion(
    val fpjsProdDomain: String,
    val fpjsPrimaryDomain: String,
    val productionEndpoint: String,
    val productionScriptsEndpoint: String) {

    usWest(
        fpjsProdDomain = "https://advanced.neuro-id.com",
        fpjsPrimaryDomain = "https://dn.neuroid.cloud/iynlfqcb0t",
        productionEndpoint = "https://receiver.neuroid.cloud/",
        productionScriptsEndpoint = "https://scripts.neuro-id.com/")
}
```
Each region should contain the 4 attributes shown above. 

Configuration of the SDK is as follows:
```
  NeuroID.BuilderConfig(
            this,
            NIDConfiguration("key_live_MwC5DQNYzRsRhnnYjvz1fJtp",
            isAdvancedDevice = true,
            region = NIDRegion.usWest)
        ).build()
```
If the region parameter is not included or an unsupported region is used in the NIDConfiguration, the default `usWest` region will be used. Right now only the `usWest` region is supported. 