### PR TITLE
ENG-11725 add ktlint, will run on PR creation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Pre-commit hook: runs ktlintCheck on the NeuroID module if any staged
+# Kotlin files under NeuroID/ are part of this commit.
+#
+# Install with: bash scripts/setup-git-hooks.sh
+
+STAGED_KT_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- 'NeuroID/**/*.kt')
+
+if [ -z "$STAGED_KT_FILES" ]; then
+    exit 0
+fi
+
+echo "Running ktlintCheck on NeuroID module before commit..."
+./gradlew :NeuroID:ktlintCheck --quiet
+
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo ""
+    echo "❌ ktlint found style violations. Commit aborted."
+    echo "   Fix them manually, or run:"
+    echo "     ./gradlew :NeuroID:ktlintFormat"
+    echo "   to auto-fix (review the diff before committing, it can reformat"
+    echo "   unrelated pre-existing code covered by config/ktlint/baseline.xml)."
+    exit 1
+fi
+
+echo "✅ ktlint check passed."
+exit 0
+

--- a/.github/workflows/github-actions-unit-test.yml
+++ b/.github/workflows/github-actions-unit-test.yml
@@ -13,6 +13,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      # Kotlin style check
+      - name: ktlint Check
+        run: ./gradlew :NeuroID:ktlintCheck
+
+      # Android Lint (android flavour)
+      - name: Android Lint (android)
+        run: ./gradlew :NeuroID:lintAndroidLibDebug
+
+      # Android Lint (reactNative flavour)
+      - name: Android Lint (reactNative)
+        run: ./gradlew :NeuroID:lintReactNativeLibDebug
+
+      - name: Upload Lint Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: NeuroID/build/reports/lint-results-*.html
+
   buildAllFlavors:
     name: Build All Flavors
     runs-on: ubuntu-latest

--- a/NeuroID/build.gradle
+++ b/NeuroID/build.gradle
@@ -5,6 +5,18 @@ plugins {
     id 'maven-publish'
     id 'jacoco'
     id 'org.sonarqube' version '6.3.1.5724'
+    id 'org.jlleitschuh.gradle.ktlint'
+}
+
+ktlint {
+    version.set("1.3.1")
+    android.set(true)
+    ignoreFailures.set(false)
+    outputToConsole.set(true)
+    baseline.set(file("config/ktlint/baseline.xml"))
+    filter {
+        exclude { it.file.path.contains("${buildDir}${File.separator}") }
+    }
 }
 def versionPropsFile = rootProject.file("version.properties")
 def versionProps = new Properties()
@@ -114,6 +126,10 @@ android {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
+    }
+
+    lint {
+        baseline = file("lint-baseline.xml")
     }
 }
 

--- a/NeuroID/config/ktlint/baseline.xml
+++ b/NeuroID/config/ktlint/baseline.xml
@@ -1,0 +1,1715 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+    <file name="src/main/java/com/neuroid/tracker/NeuroID.kt">
+        <error line="14" column="1" source="standard:no-unused-imports" />
+        <error line="85" column="58" source="standard:trailing-comma-on-declaration-site" />
+        <error line="86" column="1" source="standard:no-blank-line-in-list" />
+        <error line="87" column="1" source="standard:indent" />
+        <error line="200" column="1" source="standard:no-consecutive-blank-lines" />
+        <error line="288" column="37" source="standard:function-signature" />
+        <error line="288" column="55" source="standard:function-signature" />
+        <error line="288" column="96" source="standard:function-signature" />
+        <error line="331" column="51" source="standard:trailing-comma-on-declaration-site" />
+        <error line="342" column="48" source="standard:trailing-comma-on-call-site" />
+        <error line="355" column="53" source="standard:trailing-comma-on-declaration-site" />
+        <error line="366" column="31" source="standard:trailing-comma-on-call-site" />
+        <error line="383" column="65" source="standard:modifier-list-spacing" />
+        <error line="386" column="21" source="standard:annotation-spacing" />
+        <error line="429" column="40" source="standard:trailing-comma-on-call-site" />
+        <error line="601" column="53" source="standard:parameter-list-wrapping" />
+        <error line="601" column="53" source="standard:wrapping" />
+        <error line="601" column="53" source="standard:function-signature" />
+        <error line="602" column="1" source="standard:indent" />
+        <error line="602" column="53" source="standard:function-signature" />
+        <error line="602" column="100" source="standard:wrapping" />
+        <error line="602" column="101" source="standard:parameter-list-wrapping" />
+        <error line="602" column="101" source="standard:function-signature" />
+        <error line="602" column="101" source="standard:trailing-comma-on-declaration-site" />
+        <error line="604" column="39" source="standard:wrapping" />
+        <error line="604" column="39" source="standard:argument-list-wrapping" />
+        <error line="607" column="26" source="standard:wrapping" />
+        <error line="607" column="27" source="standard:argument-list-wrapping" />
+        <error line="607" column="27" source="standard:trailing-comma-on-call-site" />
+        <error line="638" column="50" source="standard:function-expression-body" />
+        <error line="656" column="38" source="standard:function-expression-body" />
+        <error line="683" column="56" source="standard:function-expression-body" />
+        <error line="698" column="21" source="standard:wrapping" />
+        <error line="698" column="21" source="standard:argument-list-wrapping" />
+        <error line="699" column="41" source="standard:wrapping" />
+        <error line="699" column="42" source="standard:argument-list-wrapping" />
+        <error line="699" column="42" source="standard:trailing-comma-on-call-site" />
+        <error line="702" column="21" source="standard:wrapping" />
+        <error line="702" column="21" source="standard:argument-list-wrapping" />
+        <error line="703" column="43" source="standard:wrapping" />
+        <error line="703" column="44" source="standard:argument-list-wrapping" />
+        <error line="703" column="44" source="standard:trailing-comma-on-call-site" />
+        <error line="704" column="57" source="standard:function-expression-body" />
+        <error line="708" column="56" source="standard:function-expression-body" />
+        <error line="714" column="77" source="standard:function-expression-body" />
+        <error line="736" column="45" source="standard:function-expression-body" />
+        <error line="787" column="31" source="standard:multiline-expression-wrapping" />
+        <error line="789" column="29" source="standard:wrapping" />
+        <error line="789" column="30" source="standard:argument-list-wrapping" />
+        <error line="789" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="812" column="13" source="standard:function-signature" />
+        <error line="813" column="13" source="standard:function-signature" />
+        <error line="814" column="13" source="standard:function-signature" />
+        <error line="815" column="13" source="standard:function-signature" />
+        <error line="816" column="13" source="standard:function-signature" />
+        <error line="817" column="13" source="standard:function-signature" />
+        <error line="818" column="13" source="standard:function-signature" />
+        <error line="819" column="13" source="standard:function-signature" />
+        <error line="820" column="13" source="standard:function-signature" />
+        <error line="821" column="13" source="standard:function-signature" />
+        <error line="822" column="13" source="standard:function-signature" />
+        <error line="823" column="13" source="standard:function-signature" />
+        <error line="824" column="13" source="standard:function-signature" />
+        <error line="825" column="13" source="standard:function-signature" />
+        <error line="826" column="13" source="standard:function-signature" />
+        <error line="827" column="13" source="standard:function-signature" />
+        <error line="828" column="13" source="standard:function-signature" />
+        <error line="829" column="13" source="standard:function-signature" />
+        <error line="830" column="13" source="standard:function-signature" />
+        <error line="831" column="13" source="standard:function-signature" />
+        <error line="832" column="13" source="standard:function-signature" />
+        <error line="833" column="13" source="standard:function-signature" />
+        <error line="834" column="13" source="standard:function-signature" />
+        <error line="835" column="13" source="standard:function-signature" />
+        <error line="836" column="13" source="standard:function-signature" />
+        <error line="837" column="13" source="standard:function-signature" />
+        <error line="838" column="13" source="standard:function-signature" />
+        <error line="839" column="13" source="standard:function-signature" />
+        <error line="840" column="13" source="standard:function-signature" />
+        <error line="841" column="13" source="standard:function-signature" />
+        <error line="842" column="13" source="standard:function-signature" />
+        <error line="843" column="13" source="standard:function-signature" />
+        <error line="844" column="13" source="standard:function-signature" />
+        <error line="845" column="13" source="standard:function-signature" />
+        <error line="846" column="13" source="standard:function-signature" />
+        <error line="847" column="13" source="standard:function-signature" />
+        <error line="848" column="13" source="standard:function-signature" />
+        <error line="849" column="13" source="standard:function-signature" />
+        <error line="850" column="13" source="standard:function-signature" />
+        <error line="851" column="13" source="standard:function-signature" />
+        <error line="852" column="13" source="standard:function-signature" />
+        <error line="853" column="13" source="standard:function-signature" />
+        <error line="854" column="13" source="standard:function-signature" />
+        <error line="855" column="13" source="standard:function-signature" />
+        <error line="856" column="13" source="standard:function-signature" />
+        <error line="857" column="13" source="standard:function-signature" />
+        <error line="858" column="13" source="standard:function-signature" />
+        <error line="859" column="13" source="standard:function-signature" />
+        <error line="860" column="13" source="standard:function-signature" />
+        <error line="861" column="13" source="standard:function-signature" />
+        <error line="862" column="13" source="standard:function-signature" />
+        <error line="863" column="13" source="standard:function-signature" />
+        <error line="864" column="13" source="standard:function-signature" />
+        <error line="865" column="13" source="standard:function-signature" />
+        <error line="866" column="13" source="standard:function-signature" />
+        <error line="867" column="13" source="standard:function-signature" />
+        <error line="868" column="13" source="standard:function-signature" />
+        <error line="869" column="13" source="standard:function-signature" />
+        <error line="870" column="13" source="standard:function-signature" />
+        <error line="871" column="13" source="standard:function-signature" />
+        <error line="872" column="13" source="standard:function-signature" />
+        <error line="873" column="9" source="standard:function-signature" />
+        <error line="953" column="30" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/NeuroIDPublic.kt">
+        <error line="35" column="17" source="standard:wrapping" />
+        <error line="35" column="17" source="standard:argument-list-wrapping" />
+        <error line="36" column="39" source="standard:wrapping" />
+        <error line="36" column="40" source="standard:argument-list-wrapping" />
+        <error line="36" column="40" source="standard:trailing-comma-on-call-site" />
+        <error line="47" column="17" source="standard:wrapping" />
+        <error line="47" column="17" source="standard:argument-list-wrapping" />
+        <error line="48" column="37" source="standard:wrapping" />
+        <error line="48" column="38" source="standard:argument-list-wrapping" />
+        <error line="48" column="38" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/callbacks/ActivityCallbacks.kt">
+        <error line="163" column="15" source="standard:wrapping" />
+        <error line="163" column="16" source="standard:argument-list-wrapping" />
+        <error line="163" column="36" source="standard:multiline-expression-wrapping" />
+        <error line="163" column="42" source="standard:colon-spacing" />
+        <error line="165" column="23" source="standard:keyword-spacing" />
+        <error line="168" column="37" source="standard:multiline-expression-wrapping" />
+        <error line="177" column="37" source="standard:multiline-expression-wrapping" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/callbacks/FragmentCallbacks.kt">
+        <error line="21" column="17" source="standard:backing-property-naming" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/callbacks/NIDGlobalEventCallback.kt">
+        <error line="107" column="65" source="standard:function-expression-body" />
+        <error line="111" column="73" source="standard:function-expression-body" />
+        <error line="127" column="77" source="standard:function-expression-body" />
+        <error line="131" column="81" source="standard:function-expression-body" />
+        <error line="135" column="103" source="standard:function-expression-body" />
+        <error line="139" column="52" source="standard:function-expression-body" />
+        <error line="146" column="16" source="standard:function-expression-body" />
+        <error line="154" column="16" source="standard:function-expression-body" />
+        <error line="161" column="16" source="standard:function-expression-body" />
+        <error line="168" column="16" source="standard:function-expression-body" />
+        <error line="172" column="87" source="standard:function-expression-body" />
+        <error line="176" column="37" source="standard:function-expression-body" />
+        <error line="180" column="52" source="standard:function-expression-body" />
+        <error line="184" column="39" source="standard:function-expression-body" />
+        <error line="188" column="41" source="standard:function-expression-body" />
+        <error line="195" column="7" source="standard:function-expression-body" />
+        <error line="199" column="47" source="standard:function-expression-body" />
+        <error line="204" column="72" source="standard:function-expression-body" />
+        <error line="208" column="92" source="standard:function-expression-body" />
+        <error line="216" column="20" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/callbacks/NIDSensorGenListener.kt">
+        <error line="8" column="28" source="standard:parameter-list-wrapping" />
+        <error line="8" column="28" source="standard:wrapping" />
+        <error line="8" column="28" source="standard:class-signature" />
+        <error line="9" column="1" source="standard:indent" />
+        <error line="9" column="65" source="standard:wrapping" />
+        <error line="9" column="66" source="standard:parameter-list-wrapping" />
+        <error line="9" column="66" source="standard:class-signature" />
+        <error line="9" column="66" source="standard:trailing-comma-on-declaration-site" />
+        <error line="10" column="5" source="standard:class-signature" />
+        <error line="50" column="16" source="standard:class-signature" />
+        <error line="50" column="31" source="standard:class-signature" />
+        <error line="50" column="49" source="standard:class-signature" />
+        <error line="50" column="67" source="standard:class-signature" />
+        <error line="50" column="83" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/callbacks/NIDSensorHelper.kt">
+        <error line="22" column="35" source="standard:function-expression-body" />
+        <error line="95" column="29" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/events/NIDConstants.kt">
+        <error line="83" column="27" source="standard:class-signature" />
+        <error line="83" column="46" source="standard:class-signature" />
+        <error line="83" column="60" source="standard:class-signature" />
+        <error line="87" column="1" source="standard:no-blank-line-before-rbrace" />
+        <error line="88" column="1" source="standard:enum-wrapping" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/events/NIDIdentifyViews.kt">
+        <error line="1" column="1" source="standard:filename" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/events/RegistrationIdentificationHelper.kt">
+        <error line="71" column="33" source="standard:function-signature" />
+        <error line="71" column="51" source="standard:function-signature" />
+        <error line="71" column="69" source="standard:function-signature" />
+        <error line="227" column="27" source="standard:function-signature" />
+        <error line="227" column="45" source="standard:function-signature" />
+        <error line="227" column="55" source="standard:function-signature" />
+        <error line="471" column="27" source="standard:class-signature" />
+        <error line="471" column="52" source="standard:class-signature" />
+        <error line="477" column="43" source="standard:function-expression-body" />
+        <error line="509" column="40" source="standard:function-expression-body" />
+        <error line="542" column="86" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/events/TouchEventManager.kt">
+        <error line="6" column="1" source="standard:no-wildcard-imports" />
+        <error line="23" column="45" source="standard:trailing-comma-on-declaration-site" />
+        <error line="28" column="50" source="standard:comment-spacing" />
+        <error line="129" column="119" source="standard:trailing-comma-on-call-site" />
+        <error line="140" column="24" source="standard:unary-op-spacing" />
+        <error line="144" column="23" source="standard:unary-op-spacing" />
+        <error line="354" column="39" source="standard:class-signature" />
+        <error line="354" column="54" source="standard:class-signature" />
+        <error line="354" column="77" source="standard:class-signature" />
+        <error line="354" column="92" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt">
+        <error line="33" column="53" source="standard:wrapping" />
+        <error line="33" column="54" source="standard:argument-list-wrapping" />
+        <error line="59" column="53" source="standard:wrapping" />
+        <error line="59" column="54" source="standard:argument-list-wrapping" />
+        <error line="67" column="35" source="standard:parameter-list-wrapping" />
+        <error line="67" column="35" source="standard:wrapping" />
+        <error line="67" column="35" source="standard:function-signature" />
+        <error line="68" column="1" source="standard:indent" />
+        <error line="68" column="35" source="standard:function-signature" />
+        <error line="69" column="1" source="standard:indent" />
+        <error line="69" column="35" source="standard:function-signature" />
+        <error line="70" column="1" source="standard:indent" />
+        <error line="70" column="35" source="standard:function-signature" />
+        <error line="70" column="70" source="standard:wrapping" />
+        <error line="70" column="71" source="standard:parameter-list-wrapping" />
+        <error line="70" column="71" source="standard:function-signature" />
+        <error line="70" column="71" source="standard:trailing-comma-on-declaration-site" />
+        <error line="70" column="75" source="standard:multiline-expression-wrapping" />
+        <error line="70" column="75" source="standard:function-signature" />
+        <error line="83" column="35" source="standard:trailing-comma-on-call-site" />
+        <error line="90" column="40" source="standard:trailing-comma-on-call-site" />
+        <error line="104" column="53" source="standard:trailing-comma-on-declaration-site" />
+        <error line="109" column="15" source="standard:multiline-expression-wrapping" />
+        <error line="113" column="47" source="standard:chain-method-continuation" />
+        <error line="114" column="30" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/extensions/NIDTextExtensions.kt">
+        <error line="6" column="32" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt">
+        <error line="42" column="52" source="standard:function-expression-body" />
+        <error line="50" column="11" source="standard:function-expression-body" />
+        <error line="118" column="65" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/AdvancedDeviceModels.kt">
+        <error line="3" column="34" source="standard:class-signature" />
+        <error line="3" column="54" source="standard:class-signature" />
+        <error line="3" column="69" source="standard:class-signature" />
+        <error line="5" column="35" source="standard:class-signature" />
+        <error line="5" column="52" source="standard:class-signature" />
+        <error line="5" column="74" source="standard:class-signature" />
+        <error line="5" column="101" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/ApplicationMetaData.kt">
+        <error line="11" column="42" source="standard:function-expression-body" />
+        <error line="15" column="33" source="standard:trailing-comma-on-call-site" />
+        <error line="19" column="36" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/NIDConfiguration.kt">
+        <error line="3" column="1" source="standard:no-consecutive-blank-lines" />
+        <error line="4" column="29" source="standard:parameter-list-wrapping" />
+        <error line="4" column="29" source="standard:wrapping" />
+        <error line="4" column="29" source="standard:class-signature" />
+        <error line="5" column="1" source="standard:indent" />
+        <error line="6" column="1" source="standard:indent" />
+        <error line="7" column="1" source="standard:indent" />
+        <error line="8" column="1" source="standard:indent" />
+        <error line="9" column="1" source="standard:indent" />
+        <error line="9" column="69" source="standard:trailing-comma-on-declaration-site" />
+        <error line="10" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/NIDEventModel.kt">
+        <error line="105" column="32" source="standard:function-expression-body" />
+        <error line="189" column="23" source="standard:curly-spacing" />
+        <error line="196" column="55" source="standard:function-expression-body" />
+        <error line="223" column="45" source="standard:binary-expression-wrapping" />
+        <error line="223" column="141" source="standard:max-line-length" />
+        <error line="237" column="59" source="standard:binary-expression-wrapping" />
+        <error line="237" column="141" source="standard:max-line-length" />
+        <error line="237" column="157" source="standard:argument-list-wrapping" />
+        <error line="237" column="160" source="standard:argument-list-wrapping" />
+        <error line="237" column="162" source="standard:argument-list-wrapping" />
+        <error line="251" column="27" source="standard:class-signature" />
+        <error line="251" column="42" source="standard:class-signature" />
+        <error line="251" column="57" source="standard:class-signature" />
+        <error line="251" column="70" source="standard:class-signature" />
+        <error line="262" column="26" source="standard:class-signature" />
+        <error line="262" column="43" source="standard:class-signature" />
+        <error line="262" column="58" source="standard:class-signature" />
+        <error line="262" column="71" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/NIDRegion.kt">
+        <error line="7" column="41" source="standard:wrapping" />
+        <error line="7" column="42" source="standard:parameter-list-wrapping" />
+        <error line="7" column="42" source="standard:class-signature" />
+        <error line="7" column="42" source="standard:trailing-comma-on-declaration-site" />
+        <error line="8" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="9" column="5" source="standard:enum-entry-name-case" />
+        <error line="13" column="68" source="standard:trailing-comma-on-call-site" />
+        <error line="16" column="5" source="standard:enum-entry-name-case" />
+        <error line="20" column="68" source="standard:trailing-comma-on-call-site" />
+        <error line="23" column="5" source="standard:enum-entry-name-case" />
+        <error line="27" column="68" source="standard:trailing-comma-on-call-site" />
+        <error line="28" column="6" source="standard:trailing-comma-on-declaration-site" />
+        <error line="29" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/NIDRemoteConfig.kt">
+        <error line="28" column="53" source="standard:trailing-comma-on-declaration-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/SessionIDOriginResult.kt">
+        <error line="3" column="34" source="standard:class-signature" />
+        <error line="3" column="54" source="standard:class-signature" />
+        <error line="3" column="78" source="standard:class-signature" />
+        <error line="3" column="99" source="standard:class-signature" />
+        <error line="3" column="117" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/models/SessionStructures.kt">
+        <error line="1" column="1" source="standard:filename" />
+        <error line="3" column="31" source="standard:class-signature" />
+        <error line="3" column="53" source="standard:class-signature" />
+        <error line="3" column="74" source="standard:final-newline" />
+        <error line="3" column="74" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt">
+        <error line="16" column="1" source="standard:no-unused-imports" />
+        <error line="24" column="1" source="standard:no-unused-imports" />
+        <error line="52" column="53" source="standard:trailing-comma-on-declaration-site" />
+        <error line="127" column="20" source="standard:trailing-comma-on-declaration-site" />
+        <error line="155" column="86" source="standard:trailing-comma-on-call-site" />
+        <error line="190" column="128" source="standard:trailing-comma-on-call-site" />
+        <error line="250" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="253" column="72" source="standard:wrapping" />
+        <error line="253" column="73" source="standard:argument-list-wrapping" />
+        <error line="253" column="73" source="standard:trailing-comma-on-call-site" />
+        <error line="265" column="31" source="standard:wrapping" />
+        <error line="265" column="32" source="standard:argument-list-wrapping" />
+        <error line="265" column="36" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/LocationService.kt">
+        <error line="26" column="23" source="standard:class-signature" />
+        <error line="26" column="111" source="standard:class-signature" />
+        <error line="32" column="36" source="standard:multiline-expression-wrapping" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/LoggerIntercepter.kt">
+        <error line="7" column="25" source="standard:class-signature" />
+        <error line="7" column="50" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDCallActivityListener.kt">
+        <error line="28" column="5" source="standard:spacing-between-declarations-with-comments" />
+        <error line="30" column="5" source="standard:spacing-between-declarations-with-comments" />
+        <error line="102" column="1" source="standard:no-consecutive-blank-lines" />
+        <error line="108" column="43" source="standard:multiline-expression-wrapping" />
+        <error line="131" column="38" source="standard:multiline-expression-wrapping" />
+        <error line="131" column="44" source="standard:colon-spacing" />
+        <error line="162" column="40" source="standard:class-signature" />
+        <error line="162" column="58" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDConfigService.kt">
+        <error line="3" column="1" source="standard:import-ordering" />
+        <error line="25" column="5" source="standard:blank-line-before-declaration" />
+        <error line="26" column="5" source="standard:blank-line-before-declaration" />
+        <error line="27" column="5" source="standard:blank-line-before-declaration" />
+        <error line="27" column="31" source="standard:function-signature" />
+        <error line="27" column="49" source="standard:function-signature" />
+        <error line="27" column="64" source="standard:function-signature" />
+        <error line="38" column="37" source="standard:trailing-comma-on-declaration-site" />
+        <error line="70" column="42" source="standard:function-signature" />
+        <error line="70" column="60" source="standard:function-signature" />
+        <error line="70" column="82" source="standard:function-signature" />
+        <error line="84" column="48" source="standard:comma-spacing" />
+        <error line="122" column="44" source="standard:trailing-comma-on-call-site" />
+        <error line="126" column="38" source="standard:function-signature" />
+        <error line="126" column="56" source="standard:function-signature" />
+        <error line="126" column="79" source="standard:function-signature" />
+        <error line="147" column="45" source="standard:trailing-comma-on-call-site" />
+        <error line="155" column="42" source="standard:function-expression-body" />
+        <error line="165" column="28" source="standard:function-signature" />
+        <error line="165" column="46" source="standard:function-signature" />
+        <error line="165" column="73" source="standard:function-signature" />
+        <error line="183" column="40" source="standard:function-signature" />
+        <error line="183" column="58" source="standard:function-signature" />
+        <error line="183" column="73" source="standard:function-signature" />
+        <error line="184" column="55" source="standard:op-spacing" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDEventSender.kt">
+        <error line="39" column="45" source="standard:trailing-comma-on-declaration-site" />
+        <error line="40" column="24" source="standard:class-signature" />
+        <error line="40" column="24" source="standard:class-signature" />
+        <error line="136" column="47" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDHttpService.kt">
+        <error line="28" column="18" source="standard:class-signature" />
+        <error line="28" column="18" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDIdentifierService.kt">
+        <error line="46" column="34" source="standard:function-signature" />
+        <error line="46" column="52" source="standard:function-signature" />
+        <error line="46" column="87" source="standard:function-signature" />
+        <error line="145" column="29" source="standard:function-signature" />
+        <error line="145" column="47" source="standard:function-signature" />
+        <error line="145" column="71" source="standard:function-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDJobServiceManager.kt">
+        <error line="80" column="30" source="standard:function-expression-body" />
+        <error line="114" column="47" source="standard:function-expression-body" />
+        <error line="139" column="48" source="standard:function-expression-body" />
+        <error line="151" column="48" source="standard:function-expression-body" />
+        <error line="193" column="36" source="standard:chain-method-continuation" />
+        <error line="193" column="50" source="standard:argument-list-wrapping" />
+        <error line="193" column="62" source="standard:argument-list-wrapping" />
+        <error line="193" column="77" source="standard:argument-list-wrapping" />
+        <error line="193" column="141" source="standard:max-line-length" />
+        <error line="193" column="152" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDNetworkListener.kt">
+        <error line="10" column="1" source="standard:no-wildcard-imports" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/service/NIDScreenCaptureService.kt">
+        <error line="33" column="36" source="standard:function-signature" />
+        <error line="33" column="56" source="standard:function-signature" />
+        <error line="33" column="89" source="standard:function-signature" />
+        <error line="33" column="131" source="standard:function-signature" />
+        <error line="42" column="33" source="standard:multiline-expression-wrapping" />
+        <error line="43" column="1" source="standard:indent" />
+        <error line="44" column="1" source="standard:indent" />
+        <error line="45" column="1" source="standard:indent" />
+        <error line="47" column="41" source="standard:multiline-expression-wrapping" />
+        <error line="53" column="36" source="standard:multiline-expression-wrapping" />
+        <error line="69" column="33" source="standard:multiline-expression-wrapping" />
+        <error line="114" column="41" source="standard:multiline-expression-wrapping" />
+        <error line="139" column="61" source="standard:condition-wrapping" />
+        <error line="142" column="58" source="standard:wrapping" />
+        <error line="143" column="1" source="standard:no-empty-first-line-in-method-block" />
+        <error line="144" column="1" source="standard:indent" />
+        <error line="145" column="1" source="standard:indent" />
+        <error line="146" column="1" source="standard:indent" />
+        <error line="147" column="1" source="standard:indent" />
+        <error line="148" column="1" source="standard:indent" />
+        <error line="149" column="1" source="standard:indent" />
+        <error line="150" column="1" source="standard:indent" />
+        <error line="151" column="1" source="standard:indent" />
+        <error line="152" column="1" source="standard:indent" />
+        <error line="152" column="125" source="standard:trailing-comma-on-call-site" />
+        <error line="153" column="1" source="standard:indent" />
+        <error line="170" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="189" column="1" source="standard:no-blank-line-before-rbrace" />
+        <error line="190" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/storage/NIDDataStoreManager.kt">
+        <error line="35" column="71" source="standard:function-expression-body" />
+        <error line="161" column="1" source="standard:no-consecutive-blank-lines" />
+        <error line="177" column="115" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/storage/NIDSharedPrefsDefaults.kt">
+        <error line="19" column="57" source="standard:trailing-comma-on-declaration-site" />
+        <error line="24" column="32" source="standard:function-expression-body" />
+        <error line="46" column="33" source="standard:function-expression-body" />
+        <error line="53" column="33" source="standard:function-expression-body" />
+        <error line="78" column="31" source="standard:no-multi-spaces" />
+        <error line="120" column="15" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/Base64Decoder.kt">
+        <error line="6" column="44" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/Constants.kt">
+        <error line="3" column="22" source="standard:class-signature" />
+        <error line="3" column="45" source="standard:class-signature" />
+        <error line="4" column="5" source="standard:enum-entry-name-case" />
+        <error line="5" column="5" source="standard:enum-entry-name-case" />
+        <error line="6" column="5" source="standard:enum-entry-name-case" />
+        <error line="7" column="5" source="standard:enum-entry-name-case" />
+        <error line="9" column="5" source="standard:enum-entry-name-case" />
+        <error line="10" column="5" source="standard:enum-entry-name-case" />
+        <error line="11" column="5" source="standard:enum-entry-name-case" />
+        <error line="12" column="5" source="standard:enum-entry-name-case" />
+        <error line="12" column="49" source="standard:trailing-comma-on-declaration-site" />
+        <error line="13" column="1" source="standard:no-blank-line-before-rbrace" />
+        <error line="14" column="1" source="standard:enum-wrapping" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/FileCreationUtils.kt">
+        <error line="8" column="26" source="standard:function-signature" />
+        <error line="8" column="40" source="standard:function-signature" />
+        <error line="8" column="56" source="standard:function-signature" />
+        <error line="9" column="5" source="standard:blank-line-before-declaration" />
+        <error line="10" column="5" source="standard:blank-line-before-declaration" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/LocationPermissionUtils.kt">
+        <error line="27" column="2" source="standard:no-trailing-spaces" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDBuildConfigWrapper.kt">
+        <error line="9" column="35" source="standard:function-expression-body" />
+        <error line="13" column="30" source="standard:function-expression-body" />
+        <error line="17" column="29" source="standard:function-expression-body" />
+        <error line="20" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDComposeTextWatcherUtils.kt">
+        <error line="5" column="34" source="standard:class-signature" />
+        <error line="5" column="54" source="standard:class-signature" />
+        <error line="43" column="27" source="standard:class-signature" />
+        <error line="43" column="43" source="standard:class-signature" />
+        <error line="43" column="59" source="standard:class-signature" />
+        <error line="43" column="82" source="standard:class-signature" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDEnvironmentProvider.kt">
+        <error line="5" column="5" source="standard:blank-line-before-declaration" />
+        <error line="10" column="5" source="standard:blank-line-before-declaration" />
+        <error line="11" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDLog.kt">
+        <error line="77" column="15" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDMetaData.kt">
+        <error line="85" column="59" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDResourcesUtils.kt">
+        <error line="8" column="5" source="standard:blank-line-before-declaration" />
+        <error line="9" column="5" source="standard:blank-line-before-declaration" />
+        <error line="10" column="5" source="standard:blank-line-before-declaration" />
+        <error line="11" column="5" source="standard:blank-line-before-declaration" />
+        <error line="12" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDRuntimeProvider.kt">
+        <error line="7" column="5" source="standard:blank-line-before-declaration" />
+        <error line="8" column="5" source="standard:blank-line-before-declaration" />
+        <error line="12" column="59" source="standard:function-expression-body" />
+        <error line="16" column="66" source="standard:function-expression-body" />
+        <error line="20" column="79" source="standard:function-expression-body" />
+        <error line="28" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDSdkVersionProvider.kt">
+        <error line="16" column="1" source="standard:no-consecutive-blank-lines" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDTagUtils.kt">
+        <error line="4" column="33" source="standard:function-expression-body" />
+        <error line="7" column="5" source="standard:blank-line-before-declaration" />
+        <error line="7" column="34" source="standard:function-expression-body" />
+        <error line="10" column="5" source="standard:blank-line-before-declaration" />
+        <error line="10" column="35" source="standard:function-expression-body" />
+        <error line="13" column="5" source="standard:blank-line-before-declaration" />
+        <error line="13" column="28" source="standard:function-expression-body" />
+        <error line="16" column="5" source="standard:blank-line-before-declaration" />
+        <error line="16" column="28" source="standard:function-expression-body" />
+        <error line="19" column="5" source="standard:blank-line-before-declaration" />
+        <error line="19" column="29" source="standard:function-expression-body" />
+        <error line="22" column="5" source="standard:blank-line-before-declaration" />
+        <error line="22" column="28" source="standard:function-expression-body" />
+        <error line="25" column="5" source="standard:blank-line-before-declaration" />
+        <error line="25" column="31" source="standard:function-expression-body" />
+        <error line="28" column="5" source="standard:blank-line-before-declaration" />
+        <error line="28" column="30" source="standard:function-expression-body" />
+        <error line="31" column="5" source="standard:blank-line-before-declaration" />
+        <error line="31" column="27" source="standard:function-expression-body" />
+        <error line="34" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDTextWatcher.kt">
+        <error line="67" column="1" source="standard:indent" />
+        <error line="68" column="1" source="standard:indent" />
+        <error line="69" column="1" source="standard:indent" />
+        <error line="70" column="1" source="standard:indent" />
+        <error line="75" column="1" source="standard:indent" />
+        <error line="76" column="1" source="standard:indent" />
+        <error line="77" column="1" source="standard:indent" />
+        <error line="78" column="1" source="standard:indent" />
+        <error line="79" column="1" source="standard:indent" />
+        <error line="91" column="49" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDTime.kt">
+        <error line="4" column="38" source="standard:function-expression-body" />
+        <error line="7" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDUuidProvider.kt">
+        <error line="7" column="5" source="standard:blank-line-before-declaration" />
+        <error line="12" column="5" source="standard:blank-line-before-declaration" />
+        <error line="13" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/NIDVersion.kt">
+        <error line="5" column="9" source="standard:function-signature" />
+        <error line="5" column="80" source="standard:function-signature" />
+        <error line="25" column="9" source="standard:function-signature" />
+        <error line="25" column="80" source="standard:function-signature" />
+        <error line="26" column="15" source="standard:function-expression-body" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/RandomGenerator.kt">
+        <error line="7" column="44" source="standard:function-expression-body" />
+        <error line="10" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/RetrofitInstantiator.kt">
+        <error line="15" column="13" source="standard:chain-method-continuation" />
+        <error line="18" column="25" source="standard:chain-method-continuation" />
+        <error line="23" column="59" source="standard:chain-method-continuation" />
+        <error line="25" column="9" source="standard:chain-method-continuation" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/RootHelper.kt">
+        <error line="5" column="1" source="standard:no-unused-imports" />
+        <error line="12" column="59" source="standard:wrapping" />
+        <error line="12" column="60" source="standard:parameter-list-wrapping" />
+        <error line="12" column="60" source="standard:class-signature" />
+        <error line="12" column="60" source="standard:trailing-comma-on-declaration-site" />
+        <error line="102" column="45" source="standard:function-expression-body" />
+        <error line="103" column="53" source="standard:condition-wrapping" />
+        <error line="104" column="42" source="standard:condition-wrapping" />
+        <error line="105" column="47" source="standard:condition-wrapping" />
+        <error line="105" column="66" source="standard:condition-wrapping" />
+        <error line="207" column="39" source="standard:function-expression-body" />
+        <error line="216" column="18" source="standard:condition-wrapping" />
+        <error line="217" column="1" source="standard:indent" />
+        <error line="218" column="1" source="standard:indent" />
+        <error line="219" column="1" source="standard:indent" />
+        <error line="220" column="1" source="standard:indent" />
+        <error line="221" column="1" source="standard:indent" />
+        <error line="222" column="1" source="standard:indent" />
+        <error line="223" column="1" source="standard:indent" />
+        <error line="227" column="1" source="standard:indent" />
+        <error line="229" column="1" source="standard:indent" />
+        <error line="230" column="1" source="standard:indent" />
+        <error line="231" column="1" source="standard:indent" />
+        <error line="232" column="1" source="standard:indent" />
+        <error line="234" column="1" source="standard:indent" />
+        <error line="236" column="1" source="standard:indent" />
+        <error line="237" column="1" source="standard:indent" />
+        <error line="239" column="1" source="standard:indent" />
+        <error line="240" column="1" source="standard:indent" />
+        <error line="241" column="1" source="standard:indent" />
+        <error line="243" column="1" source="standard:indent" />
+        <error line="244" column="1" source="standard:indent" />
+        <error line="245" column="1" source="standard:indent" />
+        <error line="246" column="1" source="standard:indent" />
+        <error line="247" column="1" source="standard:indent" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/UtilExt.kt">
+        <error line="13" column="65" source="standard:wrapping" />
+        <error line="13" column="66" source="standard:parameter-list-wrapping" />
+        <error line="13" column="66" source="standard:function-signature" />
+        <error line="13" column="66" source="standard:trailing-comma-on-declaration-site" />
+        <error line="14" column="1" source="standard:no-empty-first-line-in-method-block" />
+    </file>
+    <file name="src/main/java/com/neuroid/tracker/utils/VersionChecker.kt">
+        <error line="14" column="57" source="standard:function-expression-body" />
+        <error line="19" column="20" source="standard:parameter-list-wrapping" />
+        <error line="19" column="20" source="standard:wrapping" />
+        <error line="19" column="20" source="standard:function-signature" />
+        <error line="20" column="1" source="standard:indent" />
+        <error line="20" column="20" source="standard:function-signature" />
+        <error line="21" column="1" source="standard:indent" />
+        <error line="21" column="20" source="standard:function-signature" />
+        <error line="21" column="86" source="standard:wrapping" />
+        <error line="21" column="87" source="standard:parameter-list-wrapping" />
+        <error line="21" column="87" source="standard:function-signature" />
+        <error line="21" column="87" source="standard:trailing-comma-on-declaration-site" />
+        <error line="21" column="111" source="standard:function-expression-body" />
+        <error line="33" column="50" source="standard:op-spacing" />
+        <error line="36" column="64" source="standard:op-spacing" />
+    </file>
+    <file name="src/reactNative/java/com/neuroid/tracker/extensions/NIDRNBuilder.kt">
+        <error line="11" column="20" source="standard:parameter-list-spacing" />
+        <error line="11" column="20" source="standard:paren-spacing" />
+        <error line="11" column="20" source="standard:wrapping" />
+        <error line="11" column="21" source="standard:parameter-list-wrapping" />
+        <error line="11" column="21" source="standard:class-signature" />
+        <error line="12" column="1" source="standard:indent" />
+        <error line="13" column="1" source="standard:indent" />
+        <error line="13" column="62" source="standard:wrapping" />
+        <error line="13" column="63" source="standard:parameter-list-wrapping" />
+        <error line="13" column="63" source="standard:class-signature" />
+        <error line="13" column="63" source="standard:trailing-comma-on-declaration-site" />
+        <error line="17" column="16" source="standard:chain-method-continuation" />
+        <error line="18" column="25" source="standard:wrapping" />
+        <error line="18" column="26" source="standard:multiline-expression-wrapping" />
+        <error line="18" column="26" source="standard:argument-list-wrapping" />
+        <error line="24" column="86" source="standard:trailing-comma-on-call-site" />
+        <error line="75" column="59" source="standard:wrapping" />
+        <error line="75" column="61" source="standard:multiline-expression-wrapping" />
+        <error line="104" column="5" source="standard:enum-entry-name-case" />
+        <error line="105" column="5" source="standard:enum-entry-name-case" />
+        <error line="106" column="5" source="standard:enum-entry-name-case" />
+        <error line="107" column="5" source="standard:enum-entry-name-case" />
+        <error line="108" column="5" source="standard:enum-entry-name-case" />
+        <error line="109" column="5" source="standard:enum-entry-name-case" />
+        <error line="109" column="11" source="standard:trailing-comma-on-declaration-site" />
+        <error line="110" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt">
+        <error line="214" column="27" source="standard:op-spacing" />
+        <error line="216" column="119" source="standard:trailing-comma-on-call-site" />
+        <error line="239" column="34" source="standard:no-multi-spaces" />
+        <error line="239" column="55" source="standard:curly-spacing" />
+        <error line="239" column="116" source="standard:curly-spacing" />
+        <error line="255" column="30" source="standard:chain-method-continuation" />
+        <error line="255" column="44" source="standard:argument-list-wrapping" />
+        <error line="255" column="64" source="standard:argument-list-wrapping" />
+        <error line="255" column="96" source="standard:argument-list-wrapping" />
+        <error line="255" column="109" source="standard:argument-list-wrapping" />
+        <error line="255" column="121" source="standard:argument-list-wrapping" />
+        <error line="255" column="132" source="standard:argument-list-wrapping" />
+        <error line="255" column="139" source="standard:argument-list-wrapping" />
+        <error line="255" column="141" source="standard:max-line-length" />
+        <error line="255" column="142" source="standard:op-spacing" />
+        <error line="255" column="150" source="standard:argument-list-wrapping" />
+        <error line="255" column="162" source="standard:argument-list-wrapping" />
+        <error line="255" column="163" source="standard:op-spacing" />
+        <error line="255" column="191" source="standard:argument-list-wrapping" />
+        <error line="267" column="31" source="standard:multiline-expression-wrapping" />
+        <error line="268" column="42" source="standard:trailing-comma-on-call-site" />
+        <error line="274" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="275" column="43" source="standard:trailing-comma-on-call-site" />
+        <error line="297" column="54" source="standard:curly-spacing" />
+        <error line="297" column="115" source="standard:curly-spacing" />
+        <error line="313" column="30" source="standard:chain-method-continuation" />
+        <error line="313" column="44" source="standard:argument-list-wrapping" />
+        <error line="313" column="64" source="standard:argument-list-wrapping" />
+        <error line="313" column="96" source="standard:argument-list-wrapping" />
+        <error line="313" column="109" source="standard:argument-list-wrapping" />
+        <error line="313" column="121" source="standard:argument-list-wrapping" />
+        <error line="313" column="132" source="standard:argument-list-wrapping" />
+        <error line="313" column="141" source="standard:max-line-length" />
+        <error line="313" column="143" source="standard:argument-list-wrapping" />
+        <error line="313" column="146" source="standard:op-spacing" />
+        <error line="313" column="163" source="standard:argument-list-wrapping" />
+        <error line="313" column="175" source="standard:argument-list-wrapping" />
+        <error line="313" column="176" source="standard:op-spacing" />
+        <error line="313" column="200" source="standard:argument-list-wrapping" />
+        <error line="359" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="410" column="64" source="standard:trailing-comma-on-call-site" />
+        <error line="428" column="15" source="standard:function-literal" />
+        <error line="428" column="16" source="standard:wrapping" />
+        <error line="428" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="428" column="17" source="standard:statement-wrapping" />
+        <error line="428" column="38" source="standard:wrapping" />
+        <error line="428" column="38" source="standard:argument-list-wrapping" />
+        <error line="428" column="45" source="standard:argument-list-wrapping" />
+        <error line="428" column="52" source="standard:argument-list-wrapping" />
+        <error line="428" column="59" source="standard:argument-list-wrapping" />
+        <error line="428" column="66" source="standard:argument-list-wrapping" />
+        <error line="428" column="73" source="standard:argument-list-wrapping" />
+        <error line="428" column="80" source="standard:argument-list-wrapping" />
+        <error line="428" column="87" source="standard:argument-list-wrapping" />
+        <error line="428" column="94" source="standard:argument-list-wrapping" />
+        <error line="428" column="101" source="standard:argument-list-wrapping" />
+        <error line="428" column="108" source="standard:argument-list-wrapping" />
+        <error line="428" column="115" source="standard:argument-list-wrapping" />
+        <error line="428" column="122" source="standard:argument-list-wrapping" />
+        <error line="428" column="129" source="standard:argument-list-wrapping" />
+        <error line="429" column="20" source="standard:argument-list-wrapping" />
+        <error line="429" column="27" source="standard:argument-list-wrapping" />
+        <error line="429" column="34" source="standard:argument-list-wrapping" />
+        <error line="429" column="41" source="standard:argument-list-wrapping" />
+        <error line="429" column="48" source="standard:argument-list-wrapping" />
+        <error line="429" column="55" source="standard:argument-list-wrapping" />
+        <error line="429" column="62" source="standard:argument-list-wrapping" />
+        <error line="429" column="69" source="standard:argument-list-wrapping" />
+        <error line="429" column="76" source="standard:argument-list-wrapping" />
+        <error line="429" column="83" source="standard:argument-list-wrapping" />
+        <error line="429" column="90" source="standard:argument-list-wrapping" />
+        <error line="429" column="97" source="standard:argument-list-wrapping" />
+        <error line="429" column="104" source="standard:argument-list-wrapping" />
+        <error line="429" column="111" source="standard:argument-list-wrapping" />
+        <error line="429" column="118" source="standard:argument-list-wrapping" />
+        <error line="429" column="125" source="standard:argument-list-wrapping" />
+        <error line="429" column="132" source="standard:argument-list-wrapping" />
+        <error line="429" column="139" source="standard:argument-list-wrapping" />
+        <error line="429" column="141" source="standard:max-line-length" />
+        <error line="430" column="20" source="standard:argument-list-wrapping" />
+        <error line="430" column="27" source="standard:argument-list-wrapping" />
+        <error line="430" column="34" source="standard:argument-list-wrapping" />
+        <error line="430" column="41" source="standard:argument-list-wrapping" />
+        <error line="430" column="48" source="standard:argument-list-wrapping" />
+        <error line="430" column="55" source="standard:argument-list-wrapping" />
+        <error line="430" column="62" source="standard:argument-list-wrapping" />
+        <error line="430" column="69" source="standard:argument-list-wrapping" />
+        <error line="430" column="76" source="standard:argument-list-wrapping" />
+        <error line="430" column="83" source="standard:argument-list-wrapping" />
+        <error line="430" column="90" source="standard:argument-list-wrapping" />
+        <error line="430" column="97" source="standard:argument-list-wrapping" />
+        <error line="430" column="104" source="standard:argument-list-wrapping" />
+        <error line="430" column="111" source="standard:argument-list-wrapping" />
+        <error line="430" column="118" source="standard:argument-list-wrapping" />
+        <error line="430" column="125" source="standard:argument-list-wrapping" />
+        <error line="430" column="132" source="standard:argument-list-wrapping" />
+        <error line="430" column="139" source="standard:argument-list-wrapping" />
+        <error line="430" column="141" source="standard:max-line-length" />
+        <error line="431" column="20" source="standard:argument-list-wrapping" />
+        <error line="431" column="27" source="standard:argument-list-wrapping" />
+        <error line="431" column="34" source="standard:argument-list-wrapping" />
+        <error line="431" column="41" source="standard:argument-list-wrapping" />
+        <error line="431" column="48" source="standard:argument-list-wrapping" />
+        <error line="431" column="55" source="standard:argument-list-wrapping" />
+        <error line="431" column="62" source="standard:argument-list-wrapping" />
+        <error line="431" column="69" source="standard:argument-list-wrapping" />
+        <error line="431" column="74" source="standard:wrapping" />
+        <error line="431" column="75" source="standard:wrapping" />
+        <error line="431" column="75" source="standard:argument-list-wrapping" />
+        <error line="431" column="76" source="standard:curly-spacing" />
+        <error line="431" column="76" source="standard:statement-wrapping" />
+        <error line="431" column="76" source="standard:function-literal" />
+        <error line="502" column="30" source="standard:trailing-comma-on-declaration-site" />
+        <error line="509" column="24" source="standard:curly-spacing" />
+        <error line="509" column="56" source="standard:curly-spacing" />
+        <error line="510" column="24" source="standard:curly-spacing" />
+        <error line="510" column="53" source="standard:curly-spacing" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/AndroidTestUtils.kt">
+        <error line="12" column="1" source="standard:no-unused-imports" />
+        <error line="39" column="1" source="standard:no-unused-imports" />
+        <error line="45" column="1" source="standard:no-unused-imports" />
+        <error line="46" column="1" source="standard:no-unused-imports" />
+        <error line="58" column="84" source="standard:trailing-comma-on-declaration-site" />
+        <error line="110" column="36" source="standard:curly-spacing" />
+        <error line="288" column="12" source="standard:curly-spacing" />
+        <error line="288" column="35" source="standard:curly-spacing" />
+        <error line="289" column="12" source="standard:curly-spacing" />
+        <error line="289" column="52" source="standard:curly-spacing" />
+        <error line="290" column="12" source="standard:curly-spacing" />
+        <error line="294" column="48" source="standard:curly-spacing" />
+        <error line="296" column="68" source="standard:curly-spacing" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt">
+        <error line="3" column="1" source="standard:import-ordering" />
+        <error line="29" column="1" source="standard:no-unused-imports" />
+        <error line="119" column="16" source="standard:chain-method-continuation" />
+        <error line="126" column="19" source="standard:trailing-comma-on-call-site" />
+        <error line="127" column="14" source="standard:trailing-comma-on-call-site" />
+        <error line="230" column="62" source="standard:function-expression-body" />
+        <error line="318" column="16" source="standard:chain-method-continuation" />
+        <error line="320" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="331" column="16" source="standard:chain-method-continuation" />
+        <error line="333" column="88" source="standard:trailing-comma-on-call-site" />
+        <error line="344" column="16" source="standard:chain-method-continuation" />
+        <error line="346" column="81" source="standard:trailing-comma-on-call-site" />
+        <error line="357" column="16" source="standard:chain-method-continuation" />
+        <error line="359" column="101" source="standard:trailing-comma-on-call-site" />
+        <error line="370" column="16" source="standard:chain-method-continuation" />
+        <error line="377" column="14" source="standard:trailing-comma-on-call-site" />
+        <error line="390" column="16" source="standard:chain-method-continuation" />
+        <error line="392" column="81" source="standard:trailing-comma-on-call-site" />
+        <error line="404" column="16" source="standard:chain-method-continuation" />
+        <error line="406" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="416" column="16" source="standard:chain-method-continuation" />
+        <error line="418" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="428" column="16" source="standard:chain-method-continuation" />
+        <error line="430" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="443" column="16" source="standard:chain-method-continuation" />
+        <error line="445" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="458" column="16" source="standard:chain-method-continuation" />
+        <error line="460" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="548" column="16" source="standard:chain-method-continuation" />
+        <error line="550" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="564" column="16" source="standard:chain-method-continuation" />
+        <error line="566" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="578" column="16" source="standard:chain-method-continuation" />
+        <error line="580" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="592" column="16" source="standard:chain-method-continuation" />
+        <error line="594" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="606" column="16" source="standard:chain-method-continuation" />
+        <error line="608" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="620" column="16" source="standard:chain-method-continuation" />
+        <error line="622" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="634" column="16" source="standard:chain-method-continuation" />
+        <error line="636" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="650" column="16" source="standard:chain-method-continuation" />
+        <error line="652" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="669" column="16" source="standard:chain-method-continuation" />
+        <error line="671" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="683" column="16" source="standard:chain-method-continuation" />
+        <error line="685" column="87" source="standard:trailing-comma-on-call-site" />
+        <error line="699" column="16" source="standard:chain-method-continuation" />
+        <error line="701" column="86" source="standard:trailing-comma-on-call-site" />
+        <error line="793" column="22" source="standard:trailing-comma-on-call-site" />
+        <error line="950" column="22" source="standard:trailing-comma-on-call-site" />
+        <error line="1120" column="22" source="standard:trailing-comma-on-call-site" />
+        <error line="1158" column="22" source="standard:trailing-comma-on-call-site" />
+        <error line="1182" column="31" source="standard:trailing-comma-on-call-site" />
+        <error line="1191" column="41" source="standard:trailing-comma-on-call-site" />
+        <error line="1192" column="18" source="standard:trailing-comma-on-call-site" />
+        <error line="1212" column="17" source="standard:trailing-comma-on-call-site" />
+        <error line="1217" column="17" source="standard:trailing-comma-on-call-site" />
+        <error line="1337" column="14" source="standard:curly-spacing" />
+        <error line="1337" column="57" source="standard:curly-spacing" />
+        <error line="2367" column="14" source="standard:curly-spacing" />
+        <error line="2367" column="55" source="standard:curly-spacing" />
+        <error line="2367" column="57" source="standard:no-multi-spaces" />
+        <error line="2428" column="14" source="standard:curly-spacing" />
+        <error line="2428" column="55" source="standard:curly-spacing" />
+        <error line="2428" column="57" source="standard:no-multi-spaces" />
+        <error line="2734" column="22" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/callbacks/ActivityCallbacksUnitTests.kt">
+        <error line="26" column="27" source="standard:no-multi-spaces" />
+        <error line="26" column="28" source="standard:function-start-of-body-spacing" />
+        <error line="26" column="28" source="standard:function-signature" />
+        <error line="47" column="34" source="standard:no-multi-spaces" />
+        <error line="47" column="35" source="standard:function-start-of-body-spacing" />
+        <error line="47" column="35" source="standard:function-signature" />
+        <error line="61" column="51" source="standard:no-multi-spaces" />
+        <error line="61" column="52" source="standard:function-start-of-body-spacing" />
+        <error line="61" column="52" source="standard:function-signature" />
+        <error line="121" column="54" source="standard:no-multi-spaces" />
+        <error line="121" column="55" source="standard:function-start-of-body-spacing" />
+        <error line="121" column="55" source="standard:function-signature" />
+        <error line="188" column="33" source="standard:no-multi-spaces" />
+        <error line="188" column="34" source="standard:function-start-of-body-spacing" />
+        <error line="188" column="34" source="standard:function-signature" />
+        <error line="217" column="34" source="standard:no-multi-spaces" />
+        <error line="217" column="35" source="standard:function-start-of-body-spacing" />
+        <error line="217" column="35" source="standard:function-signature" />
+        <error line="237" column="66" source="standard:wrapping" />
+        <error line="237" column="66" source="standard:argument-list-wrapping" />
+        <error line="238" column="40" source="standard:wrapping" />
+        <error line="238" column="41" source="standard:argument-list-wrapping" />
+        <error line="238" column="41" source="standard:trailing-comma-on-call-site" />
+        <error line="259" column="34" source="standard:no-multi-spaces" />
+        <error line="259" column="35" source="standard:function-start-of-body-spacing" />
+        <error line="259" column="35" source="standard:function-signature" />
+        <error line="273" column="44" source="standard:no-multi-spaces" />
+        <error line="273" column="45" source="standard:function-start-of-body-spacing" />
+        <error line="273" column="45" source="standard:function-signature" />
+        <error line="287" column="36" source="standard:no-multi-spaces" />
+        <error line="287" column="37" source="standard:function-start-of-body-spacing" />
+        <error line="287" column="37" source="standard:function-signature" />
+        <error line="329" column="65" source="standard:no-multi-spaces" />
+        <error line="329" column="66" source="standard:function-start-of-body-spacing" />
+        <error line="329" column="66" source="standard:function-signature" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/callbacks/FragmentCallbacksUnitTests.kt">
+        <error line="25" column="43" source="standard:no-multi-spaces" />
+        <error line="25" column="44" source="standard:function-start-of-body-spacing" />
+        <error line="25" column="44" source="standard:function-signature" />
+        <error line="83" column="49" source="standard:no-multi-spaces" />
+        <error line="83" column="50" source="standard:function-start-of-body-spacing" />
+        <error line="83" column="50" source="standard:function-signature" />
+        <error line="154" column="34" source="standard:no-multi-spaces" />
+        <error line="154" column="35" source="standard:function-start-of-body-spacing" />
+        <error line="154" column="35" source="standard:function-signature" />
+        <error line="173" column="38" source="standard:no-multi-spaces" />
+        <error line="173" column="39" source="standard:function-start-of-body-spacing" />
+        <error line="173" column="39" source="standard:function-signature" />
+        <error line="193" column="52" source="standard:no-multi-spaces" />
+        <error line="193" column="53" source="standard:function-start-of-body-spacing" />
+        <error line="193" column="53" source="standard:function-signature" />
+        <error line="225" column="51" source="standard:no-multi-spaces" />
+        <error line="225" column="52" source="standard:function-start-of-body-spacing" />
+        <error line="225" column="52" source="standard:function-signature" />
+        <error line="260" column="33" source="standard:no-multi-spaces" />
+        <error line="260" column="34" source="standard:function-start-of-body-spacing" />
+        <error line="260" column="34" source="standard:function-signature" />
+        <error line="278" column="34" source="standard:no-multi-spaces" />
+        <error line="278" column="35" source="standard:function-start-of-body-spacing" />
+        <error line="278" column="35" source="standard:function-signature" />
+        <error line="296" column="36" source="standard:no-multi-spaces" />
+        <error line="296" column="37" source="standard:function-start-of-body-spacing" />
+        <error line="296" column="37" source="standard:function-signature" />
+        <error line="314" column="35" source="standard:no-multi-spaces" />
+        <error line="314" column="36" source="standard:function-start-of-body-spacing" />
+        <error line="314" column="36" source="standard:function-signature" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/callbacks/NIDContextMenuCallbacksUnitTests.kt">
+        <error line="19" column="26" source="standard:no-multi-spaces" />
+        <error line="19" column="27" source="standard:function-start-of-body-spacing" />
+        <error line="19" column="27" source="standard:function-signature" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/callbacks/NIDGlobalEventCallbackTest.kt">
+        <error line="3" column="1" source="standard:import-ordering" />
+        <error line="47" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="63" column="36" source="standard:function-signature" />
+        <error line="63" column="52" source="standard:function-signature" />
+        <error line="63" column="74" source="standard:function-signature" />
+        <error line="115" column="24" source="standard:argument-list-wrapping" />
+        <error line="115" column="31" source="standard:argument-list-wrapping" />
+        <error line="115" column="38" source="standard:argument-list-wrapping" />
+        <error line="115" column="45" source="standard:argument-list-wrapping" />
+        <error line="115" column="52" source="standard:argument-list-wrapping" />
+        <error line="115" column="59" source="standard:argument-list-wrapping" />
+        <error line="126" column="30" source="standard:argument-list-wrapping" />
+        <error line="126" column="44" source="standard:argument-list-wrapping" />
+        <error line="126" column="51" source="standard:argument-list-wrapping" />
+        <error line="126" column="81" source="standard:argument-list-wrapping" />
+        <error line="126" column="88" source="standard:argument-list-wrapping" />
+        <error line="126" column="95" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/callbacks/SensorHelperTests.kt">
+        <error line="252" column="26" source="standard:function-signature" />
+        <error line="252" column="48" source="standard:function-signature" />
+        <error line="252" column="66" source="standard:parameter-list-spacing" />
+        <error line="252" column="66" source="standard:paren-spacing" />
+        <error line="252" column="67" source="standard:function-signature" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/events/AdditionalListenersTest.kt">
+        <error line="44" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="48" column="28" source="standard:trailing-comma-on-call-site" />
+        <error line="66" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="68" column="1" source="standard:indent" />
+        <error line="69" column="1" source="standard:indent" />
+        <error line="138" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="142" column="28" source="standard:trailing-comma-on-call-site" />
+        <error line="229" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="233" column="28" source="standard:trailing-comma-on-call-site" />
+        <error line="316" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="319" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="337" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="339" column="1" source="standard:indent" />
+        <error line="408" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="411" column="17" source="standard:trailing-comma-on-call-site" />
+        <error line="518" column="1" source="standard:no-consecutive-blank-lines" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/events/RegistrationIdentificationHelperTest.kt">
+        <error line="123" column="23" source="standard:no-multi-spaces" />
+        <error line="124" column="23" source="standard:no-multi-spaces" />
+        <error line="125" column="21" source="standard:no-multi-spaces" />
+        <error line="126" column="21" source="standard:no-multi-spaces" />
+        <error line="152" column="23" source="standard:no-multi-spaces" />
+        <error line="179" column="23" source="standard:no-multi-spaces" />
+        <error line="284" column="41" source="standard:multiline-expression-wrapping" />
+        <error line="309" column="41" source="standard:multiline-expression-wrapping" />
+        <error line="325" column="41" source="standard:multiline-expression-wrapping" />
+        <error line="345" column="41" source="standard:multiline-expression-wrapping" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/events/SingleTargetListenerRegisterTest.kt">
+        <error line="59" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="64" column="19" source="standard:trailing-comma-on-call-site" />
+        <error line="104" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="109" column="24" source="standard:trailing-comma-on-call-site" />
+        <error line="130" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="131" column="53" source="standard:trailing-comma-on-call-site" />
+        <error line="151" column="36" source="standard:trailing-comma-on-call-site" />
+        <error line="245" column="32" source="standard:trailing-comma-on-call-site" />
+        <error line="294" column="63" source="standard:curly-spacing" />
+        <error line="363" column="56" source="standard:comma-spacing" />
+        <error line="364" column="56" source="standard:comma-spacing" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/events/TouchEventManagerTest.kt">
+        <error line="42" column="16" source="standard:curly-spacing" />
+        <error line="46" column="16" source="standard:curly-spacing" />
+        <error line="56" column="16" source="standard:curly-spacing" />
+        <error line="56" column="35" source="standard:curly-spacing" />
+        <error line="57" column="16" source="standard:curly-spacing" />
+        <error line="57" column="48" source="standard:curly-spacing" />
+        <error line="58" column="16" source="standard:curly-spacing" />
+        <error line="58" column="34" source="standard:curly-spacing" />
+        <error line="59" column="16" source="standard:curly-spacing" />
+        <error line="59" column="32" source="standard:curly-spacing" />
+        <error line="62" column="17" source="standard:op-spacing" />
+        <error line="65" column="47" source="standard:op-spacing" />
+        <error line="65" column="55" source="standard:op-spacing" />
+        <error line="65" column="63" source="standard:op-spacing" />
+        <error line="68" column="48" source="standard:wrapping" />
+        <error line="68" column="49" source="standard:argument-list-wrapping" />
+        <error line="68" column="49" source="standard:trailing-comma-on-call-site" />
+        <error line="76" column="16" source="standard:curly-spacing" />
+        <error line="76" column="36" source="standard:curly-spacing" />
+        <error line="77" column="16" source="standard:curly-spacing" />
+        <error line="77" column="38" source="standard:curly-spacing" />
+        <error line="78" column="16" source="standard:curly-spacing" />
+        <error line="78" column="50" source="standard:curly-spacing" />
+        <error line="79" column="16" source="standard:curly-spacing" />
+        <error line="79" column="50" source="standard:curly-spacing" />
+        <error line="80" column="16" source="standard:curly-spacing" />
+        <error line="80" column="48" source="standard:curly-spacing" />
+        <error line="83" column="17" source="standard:op-spacing" />
+        <error line="86" column="47" source="standard:op-spacing" />
+        <error line="86" column="55" source="standard:op-spacing" />
+        <error line="86" column="63" source="standard:op-spacing" />
+        <error line="89" column="46" source="standard:wrapping" />
+        <error line="89" column="47" source="standard:argument-list-wrapping" />
+        <error line="89" column="47" source="standard:trailing-comma-on-call-site" />
+        <error line="97" column="16" source="standard:curly-spacing" />
+        <error line="97" column="36" source="standard:curly-spacing" />
+        <error line="98" column="16" source="standard:curly-spacing" />
+        <error line="98" column="38" source="standard:curly-spacing" />
+        <error line="99" column="16" source="standard:curly-spacing" />
+        <error line="99" column="50" source="standard:curly-spacing" />
+        <error line="100" column="16" source="standard:curly-spacing" />
+        <error line="100" column="50" source="standard:curly-spacing" />
+        <error line="101" column="16" source="standard:curly-spacing" />
+        <error line="101" column="48" source="standard:curly-spacing" />
+        <error line="104" column="17" source="standard:op-spacing" />
+        <error line="107" column="47" source="standard:op-spacing" />
+        <error line="107" column="55" source="standard:op-spacing" />
+        <error line="107" column="63" source="standard:op-spacing" />
+        <error line="110" column="48" source="standard:wrapping" />
+        <error line="110" column="49" source="standard:argument-list-wrapping" />
+        <error line="110" column="49" source="standard:trailing-comma-on-call-site" />
+        <error line="113" column="32" source="standard:parameter-list-wrapping" />
+        <error line="113" column="32" source="standard:wrapping" />
+        <error line="113" column="32" source="standard:function-signature" />
+        <error line="113" column="51" source="standard:parameter-list-wrapping" />
+        <error line="113" column="51" source="standard:function-signature" />
+        <error line="114" column="1" source="standard:indent" />
+        <error line="114" column="24" source="standard:function-signature" />
+        <error line="114" column="51" source="standard:parameter-list-wrapping" />
+        <error line="114" column="51" source="standard:function-signature" />
+        <error line="114" column="65" source="standard:parameter-list-wrapping" />
+        <error line="114" column="65" source="standard:function-signature" />
+        <error line="115" column="1" source="standard:indent" />
+        <error line="115" column="24" source="standard:function-signature" />
+        <error line="115" column="36" source="standard:parameter-list-wrapping" />
+        <error line="115" column="36" source="standard:function-signature" />
+        <error line="115" column="48" source="standard:parameter-list-wrapping" />
+        <error line="115" column="48" source="standard:function-signature" />
+        <error line="115" column="62" source="standard:wrapping" />
+        <error line="115" column="63" source="standard:parameter-list-wrapping" />
+        <error line="115" column="63" source="standard:function-signature" />
+        <error line="115" column="63" source="standard:trailing-comma-on-declaration-site" />
+        <error line="120" column="16" source="standard:curly-spacing" />
+        <error line="120" column="45" source="standard:curly-spacing" />
+        <error line="121" column="16" source="standard:curly-spacing" />
+        <error line="122" column="16" source="standard:curly-spacing" />
+        <error line="123" column="57" source="standard:curly-spacing" />
+        <error line="128" column="16" source="standard:curly-spacing" />
+        <error line="128" column="35" source="standard:curly-spacing" />
+        <error line="129" column="16" source="standard:curly-spacing" />
+        <error line="129" column="36" source="standard:curly-spacing" />
+        <error line="133" column="57" source="standard:curly-spacing" />
+        <error line="164" column="28" source="standard:argument-list-wrapping" />
+        <error line="164" column="34" source="standard:argument-list-wrapping" />
+        <error line="164" column="41" source="standard:argument-list-wrapping" />
+        <error line="164" column="48" source="standard:argument-list-wrapping" />
+        <error line="164" column="52" source="standard:argument-list-wrapping" />
+        <error line="164" column="57" source="standard:argument-list-wrapping" />
+        <error line="164" column="66" source="standard:argument-list-wrapping" />
+        <error line="164" column="73" source="standard:argument-list-wrapping" />
+        <error line="164" column="80" source="standard:argument-list-wrapping" />
+        <error line="165" column="24" source="standard:argument-list-wrapping" />
+        <error line="165" column="31" source="standard:argument-list-wrapping" />
+        <error line="165" column="38" source="standard:argument-list-wrapping" />
+        <error line="165" column="45" source="standard:argument-list-wrapping" />
+        <error line="165" column="52" source="standard:argument-list-wrapping" />
+        <error line="165" column="59" source="standard:argument-list-wrapping" />
+        <error line="165" column="66" source="standard:argument-list-wrapping" />
+        <error line="165" column="73" source="standard:argument-list-wrapping" />
+        <error line="165" column="80" source="standard:argument-list-wrapping" />
+        <error line="166" column="28" source="standard:argument-list-wrapping" />
+        <error line="166" column="35" source="standard:argument-list-wrapping" />
+        <error line="166" column="42" source="standard:argument-list-wrapping" />
+        <error line="166" column="49" source="standard:argument-list-wrapping" />
+        <error line="166" column="56" source="standard:argument-list-wrapping" />
+        <error line="166" column="63" source="standard:argument-list-wrapping" />
+        <error line="166" column="70" source="standard:argument-list-wrapping" />
+        <error line="166" column="77" source="standard:argument-list-wrapping" />
+        <error line="166" column="84" source="standard:argument-list-wrapping" />
+        <error line="167" column="28" source="standard:argument-list-wrapping" />
+        <error line="167" column="35" source="standard:argument-list-wrapping" />
+        <error line="167" column="42" source="standard:argument-list-wrapping" />
+        <error line="167" column="49" source="standard:argument-list-wrapping" />
+        <error line="167" column="56" source="standard:argument-list-wrapping" />
+        <error line="167" column="63" source="standard:argument-list-wrapping" />
+        <error line="167" column="70" source="standard:argument-list-wrapping" />
+        <error line="167" column="77" source="standard:argument-list-wrapping" />
+        <error line="167" column="84" source="standard:argument-list-wrapping" />
+        <error line="168" column="28" source="standard:argument-list-wrapping" />
+        <error line="168" column="35" source="standard:argument-list-wrapping" />
+        <error line="168" column="42" source="standard:argument-list-wrapping" />
+        <error line="168" column="49" source="standard:argument-list-wrapping" />
+        <error line="168" column="56" source="standard:argument-list-wrapping" />
+        <error line="168" column="63" source="standard:argument-list-wrapping" />
+        <error line="168" column="70" source="standard:argument-list-wrapping" />
+        <error line="168" column="77" source="standard:argument-list-wrapping" />
+        <error line="168" column="84" source="standard:argument-list-wrapping" />
+        <error line="169" column="28" source="standard:argument-list-wrapping" />
+        <error line="169" column="35" source="standard:argument-list-wrapping" />
+        <error line="169" column="38" source="standard:argument-list-wrapping" />
+        <error line="169" column="45" source="standard:argument-list-wrapping" />
+        <error line="169" column="52" source="standard:argument-list-wrapping" />
+        <error line="169" column="59" source="standard:argument-list-wrapping" />
+        <error line="169" column="66" source="standard:argument-list-wrapping" />
+        <error line="169" column="73" source="standard:argument-list-wrapping" />
+        <error line="169" column="80" source="standard:argument-list-wrapping" />
+        <error line="169" column="85" source="standard:trailing-comma-on-call-site" />
+        <error line="175" column="28" source="standard:argument-list-wrapping" />
+        <error line="175" column="34" source="standard:argument-list-wrapping" />
+        <error line="175" column="41" source="standard:argument-list-wrapping" />
+        <error line="175" column="48" source="standard:argument-list-wrapping" />
+        <error line="175" column="52" source="standard:argument-list-wrapping" />
+        <error line="175" column="57" source="standard:argument-list-wrapping" />
+        <error line="175" column="66" source="standard:argument-list-wrapping" />
+        <error line="175" column="73" source="standard:argument-list-wrapping" />
+        <error line="175" column="80" source="standard:argument-list-wrapping" />
+        <error line="176" column="24" source="standard:argument-list-wrapping" />
+        <error line="176" column="31" source="standard:argument-list-wrapping" />
+        <error line="176" column="38" source="standard:argument-list-wrapping" />
+        <error line="176" column="45" source="standard:argument-list-wrapping" />
+        <error line="176" column="52" source="standard:argument-list-wrapping" />
+        <error line="176" column="59" source="standard:argument-list-wrapping" />
+        <error line="176" column="66" source="standard:argument-list-wrapping" />
+        <error line="176" column="73" source="standard:argument-list-wrapping" />
+        <error line="176" column="80" source="standard:argument-list-wrapping" />
+        <error line="177" column="28" source="standard:argument-list-wrapping" />
+        <error line="177" column="35" source="standard:argument-list-wrapping" />
+        <error line="177" column="42" source="standard:argument-list-wrapping" />
+        <error line="177" column="49" source="standard:argument-list-wrapping" />
+        <error line="177" column="56" source="standard:argument-list-wrapping" />
+        <error line="177" column="63" source="standard:argument-list-wrapping" />
+        <error line="177" column="70" source="standard:argument-list-wrapping" />
+        <error line="177" column="77" source="standard:argument-list-wrapping" />
+        <error line="177" column="84" source="standard:argument-list-wrapping" />
+        <error line="178" column="28" source="standard:argument-list-wrapping" />
+        <error line="178" column="35" source="standard:argument-list-wrapping" />
+        <error line="178" column="42" source="standard:argument-list-wrapping" />
+        <error line="178" column="49" source="standard:argument-list-wrapping" />
+        <error line="178" column="56" source="standard:argument-list-wrapping" />
+        <error line="178" column="63" source="standard:argument-list-wrapping" />
+        <error line="178" column="70" source="standard:argument-list-wrapping" />
+        <error line="178" column="77" source="standard:argument-list-wrapping" />
+        <error line="178" column="84" source="standard:argument-list-wrapping" />
+        <error line="179" column="28" source="standard:argument-list-wrapping" />
+        <error line="179" column="35" source="standard:argument-list-wrapping" />
+        <error line="179" column="42" source="standard:argument-list-wrapping" />
+        <error line="179" column="49" source="standard:argument-list-wrapping" />
+        <error line="179" column="56" source="standard:argument-list-wrapping" />
+        <error line="179" column="63" source="standard:argument-list-wrapping" />
+        <error line="179" column="70" source="standard:argument-list-wrapping" />
+        <error line="179" column="77" source="standard:argument-list-wrapping" />
+        <error line="179" column="84" source="standard:argument-list-wrapping" />
+        <error line="180" column="28" source="standard:argument-list-wrapping" />
+        <error line="180" column="35" source="standard:argument-list-wrapping" />
+        <error line="180" column="38" source="standard:argument-list-wrapping" />
+        <error line="180" column="45" source="standard:argument-list-wrapping" />
+        <error line="180" column="52" source="standard:argument-list-wrapping" />
+        <error line="180" column="59" source="standard:argument-list-wrapping" />
+        <error line="180" column="66" source="standard:argument-list-wrapping" />
+        <error line="180" column="73" source="standard:argument-list-wrapping" />
+        <error line="180" column="80" source="standard:argument-list-wrapping" />
+        <error line="180" column="85" source="standard:trailing-comma-on-call-site" />
+        <error line="195" column="16" source="standard:curly-spacing" />
+        <error line="195" column="39" source="standard:curly-spacing" />
+        <error line="207" column="57" source="standard:curly-spacing" />
+        <error line="212" column="16" source="standard:curly-spacing" />
+        <error line="212" column="35" source="standard:curly-spacing" />
+        <error line="213" column="16" source="standard:curly-spacing" />
+        <error line="213" column="36" source="standard:curly-spacing" />
+        <error line="217" column="57" source="standard:curly-spacing" />
+        <error line="239" column="57" source="standard:curly-spacing" />
+        <error line="244" column="16" source="standard:curly-spacing" />
+        <error line="244" column="35" source="standard:curly-spacing" />
+        <error line="245" column="16" source="standard:curly-spacing" />
+        <error line="245" column="36" source="standard:curly-spacing" />
+        <error line="249" column="57" source="standard:curly-spacing" />
+        <error line="274" column="57" source="standard:curly-spacing" />
+        <error line="279" column="16" source="standard:curly-spacing" />
+        <error line="279" column="35" source="standard:curly-spacing" />
+        <error line="280" column="16" source="standard:curly-spacing" />
+        <error line="280" column="36" source="standard:curly-spacing" />
+        <error line="284" column="57" source="standard:curly-spacing" />
+        <error line="310" column="16" source="standard:multiline-expression-wrapping" />
+        <error line="310" column="16" source="standard:wrapping" />
+        <error line="311" column="1" source="standard:indent" />
+        <error line="312" column="1" source="standard:indent" />
+        <error line="313" column="1" source="standard:indent" />
+        <error line="313" column="50" source="standard:wrapping" />
+        <error line="318" column="43" source="standard:paren-spacing" />
+        <error line="319" column="43" source="standard:paren-spacing" />
+        <error line="320" column="43" source="standard:paren-spacing" />
+        <error line="321" column="43" source="standard:paren-spacing" />
+        <error line="322" column="43" source="standard:paren-spacing" />
+        <error line="323" column="43" source="standard:paren-spacing" />
+        <error line="324" column="43" source="standard:paren-spacing" />
+        <error line="325" column="43" source="standard:paren-spacing" />
+        <error line="326" column="43" source="standard:paren-spacing" />
+        <error line="327" column="43" source="standard:paren-spacing" />
+        <error line="328" column="43" source="standard:paren-spacing" />
+        <error line="329" column="43" source="standard:paren-spacing" />
+        <error line="330" column="43" source="standard:paren-spacing" />
+        <error line="332" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/models/ApplicationMetaDataTest.kt">
+        <error line="9" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="29" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="33" column="44" source="standard:trailing-comma-on-call-site" />
+        <error line="42" column="1" source="standard:no-consecutive-blank-lines" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/models/NIDEventModelUnitTest.kt">
+        <error line="3" column="1" source="standard:no-unused-imports" />
+        <error line="4" column="1" source="standard:no-wildcard-imports" />
+        <error line="5" column="1" source="standard:no-unused-imports" />
+        <error line="6" column="1" source="standard:no-wildcard-imports" />
+        <error line="7" column="1" source="standard:no-unused-imports" />
+        <error line="8" column="1" source="standard:no-unused-imports" />
+        <error line="9" column="1" source="standard:no-unused-imports" />
+        <error line="10" column="1" source="standard:no-unused-imports" />
+        <error line="11" column="1" source="standard:no-unused-imports" />
+        <error line="12" column="1" source="standard:no-unused-imports" />
+        <error line="52" column="23" source="standard:no-multi-spaces" />
+        <error line="72" column="23" source="standard:no-multi-spaces" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/service/NIDCallActivityListenerTests.kt">
+        <error line="31" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="41" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="41" column="36" source="standard:chain-method-continuation" />
+        <error line="41" column="66" source="standard:chain-method-continuation" />
+        <error line="45" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="48" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="58" column="13" source="standard:chain-method-continuation" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/service/NIDConfigServiceTest.kt">
+        <error line="27" column="1" source="standard:no-unused-imports" />
+        <error line="34" column="1" source="standard:no-unused-imports" />
+        <error line="65" column="18" source="standard:trailing-comma-on-call-site" />
+        <error line="95" column="24" source="standard:trailing-comma-on-call-site" />
+        <error line="125" column="47" source="standard:curly-spacing" />
+        <error line="135" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="140" column="29" source="standard:wrapping" />
+        <error line="140" column="30" source="standard:argument-list-wrapping" />
+        <error line="140" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="165" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="167" column="1" source="standard:indent" />
+        <error line="168" column="1" source="standard:indent" />
+        <error line="169" column="1" source="standard:indent" />
+        <error line="170" column="1" source="standard:indent" />
+        <error line="171" column="1" source="standard:indent" />
+        <error line="172" column="1" source="standard:indent" />
+        <error line="174" column="28" source="standard:trailing-comma-on-call-site" />
+        <error line="193" column="50" source="standard:trailing-comma-on-call-site" />
+        <error line="198" column="16" source="standard:curly-spacing" />
+        <error line="198" column="39" source="standard:curly-spacing" />
+        <error line="203" column="63" source="standard:no-multi-spaces" />
+        <error line="231" column="16" source="standard:curly-spacing" />
+        <error line="231" column="39" source="standard:curly-spacing" />
+        <error line="235" column="63" source="standard:no-multi-spaces" />
+        <error line="263" column="16" source="standard:curly-spacing" />
+        <error line="263" column="39" source="standard:curly-spacing" />
+        <error line="267" column="63" source="standard:no-multi-spaces" />
+        <error line="295" column="16" source="standard:curly-spacing" />
+        <error line="295" column="39" source="standard:curly-spacing" />
+        <error line="299" column="63" source="standard:no-multi-spaces" />
+        <error line="327" column="16" source="standard:curly-spacing" />
+        <error line="327" column="39" source="standard:curly-spacing" />
+        <error line="346" column="36" source="standard:trailing-comma-on-call-site" />
+        <error line="358" column="50" source="standard:trailing-comma-on-call-site" />
+        <error line="359" column="1" source="standard:no-blank-line-in-list" />
+        <error line="388" column="34" source="standard:trailing-comma-on-call-site" />
+        <error line="445" column="1" source="standard:no-trailing-spaces" />
+        <error line="467" column="24" source="standard:wrapping" />
+        <error line="467" column="25" source="standard:argument-list-wrapping" />
+        <error line="467" column="25" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/service/NIDJobServiceManagerTest.kt">
+        <error line="3" column="1" source="standard:import-ordering" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/service/NIDNetworkListenerTest.kt">
+        <error line="11" column="1" source="standard:no-unused-imports" />
+        <error line="15" column="1" source="standard:no-unused-imports" />
+        <error line="21" column="1" source="standard:no-unused-imports" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/service/NIDScreenCaptureServiceTest.kt">
+        <error line="495" column="16" source="standard:function-literal" />
+        <error line="495" column="17" source="standard:wrapping" />
+        <error line="495" column="24" source="standard:chain-method-continuation" />
+        <error line="495" column="27" source="standard:argument-list-wrapping" />
+        <error line="495" column="34" source="standard:argument-list-wrapping" />
+        <error line="495" column="40" source="standard:function-literal" />
+        <error line="495" column="41" source="standard:wrapping" />
+        <error line="495" column="44" source="standard:chain-method-continuation" />
+        <error line="495" column="54" source="standard:argument-list-wrapping" />
+        <error line="495" column="141" source="standard:max-line-length" />
+        <error line="495" column="150" source="standard:argument-list-wrapping" />
+        <error line="495" column="152" source="standard:function-literal" />
+        <error line="495" column="153" source="standard:argument-list-wrapping" />
+        <error line="495" column="155" source="standard:function-literal" />
+        <error line="546" column="16" source="standard:function-literal" />
+        <error line="546" column="17" source="standard:wrapping" />
+        <error line="546" column="24" source="standard:chain-method-continuation" />
+        <error line="546" column="27" source="standard:argument-list-wrapping" />
+        <error line="546" column="34" source="standard:argument-list-wrapping" />
+        <error line="546" column="40" source="standard:function-literal" />
+        <error line="546" column="41" source="standard:wrapping" />
+        <error line="546" column="44" source="standard:chain-method-continuation" />
+        <error line="546" column="54" source="standard:argument-list-wrapping" />
+        <error line="546" column="141" source="standard:max-line-length" />
+        <error line="546" column="150" source="standard:argument-list-wrapping" />
+        <error line="546" column="152" source="standard:function-literal" />
+        <error line="546" column="153" source="standard:argument-list-wrapping" />
+        <error line="546" column="155" source="standard:function-literal" />
+        <error line="633" column="1" source="standard:no-consecutive-blank-lines" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt">
+        <error line="32" column="1" source="standard:no-unused-imports" />
+        <error line="55" column="16" source="standard:chain-method-continuation" />
+        <error line="110" column="40" source="standard:multiline-expression-wrapping" />
+        <error line="113" column="1" source="standard:no-blank-line-in-list" />
+        <error line="114" column="9" source="standard:function-signature" />
+        <error line="116" column="26" source="standard:function-expression-body" />
+        <error line="480" column="77" source="standard:op-spacing" />
+        <error line="480" column="83" source="standard:comma-spacing" />
+        <error line="514" column="77" source="standard:op-spacing" />
+        <error line="556" column="77" source="standard:op-spacing" />
+        <error line="592" column="77" source="standard:op-spacing" />
+        <error line="624" column="78" source="standard:op-spacing" />
+        <error line="687" column="78" source="standard:op-spacing" />
+        <error line="735" column="78" source="standard:op-spacing" />
+        <error line="735" column="86" source="standard:no-multi-spaces" />
+        <error line="792" column="78" source="standard:op-spacing" />
+        <error line="1059" column="52" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/storage/NIDDataStoreManagerUnitTests.kt">
+        <error line="166" column="16" source="standard:curly-spacing" />
+        <error line="166" column="46" source="standard:curly-spacing" />
+        <error line="179" column="16" source="standard:curly-spacing" />
+        <error line="179" column="38" source="standard:curly-spacing" />
+        <error line="182" column="16" source="standard:curly-spacing" />
+        <error line="182" column="45" source="standard:curly-spacing" />
+        <error line="183" column="16" source="standard:curly-spacing" />
+        <error line="183" column="50" source="standard:curly-spacing" />
+        <error line="184" column="16" source="standard:curly-spacing" />
+        <error line="184" column="47" source="standard:curly-spacing" />
+        <error line="185" column="16" source="standard:curly-spacing" />
+        <error line="185" column="51" source="standard:curly-spacing" />
+        <error line="188" column="15" source="standard:curly-spacing" />
+        <error line="188" column="132" source="standard:curly-spacing" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/storage/NIDSharedPrefsDefaultsTests.kt">
+        <error line="15" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="25" column="40" source="standard:trailing-comma-on-declaration-site" />
+        <error line="32" column="26" source="standard:multiline-expression-wrapping" />
+        <error line="64" column="37" source="standard:trailing-comma-on-declaration-site" />
+        <error line="68" column="1" source="standard:no-trailing-spaces" />
+        <error line="71" column="1" source="standard:no-trailing-spaces" />
+        <error line="79" column="62" source="standard:function-expression-body" />
+        <error line="129" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="129" column="40" source="standard:wrapping" />
+        <error line="129" column="40" source="standard:argument-list-wrapping" />
+        <error line="129" column="49" source="standard:argument-list-wrapping" />
+        <error line="130" column="47" source="standard:wrapping" />
+        <error line="130" column="48" source="standard:argument-list-wrapping" />
+        <error line="130" column="48" source="standard:trailing-comma-on-call-site" />
+        <error line="143" column="56" source="standard:multiline-expression-wrapping" />
+        <error line="145" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="147" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="147" column="40" source="standard:wrapping" />
+        <error line="147" column="40" source="standard:argument-list-wrapping" />
+        <error line="147" column="59" source="standard:argument-list-wrapping" />
+        <error line="148" column="47" source="standard:wrapping" />
+        <error line="148" column="48" source="standard:argument-list-wrapping" />
+        <error line="148" column="48" source="standard:trailing-comma-on-call-site" />
+        <error line="162" column="56" source="standard:multiline-expression-wrapping" />
+        <error line="164" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="166" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="166" column="40" source="standard:wrapping" />
+        <error line="166" column="40" source="standard:argument-list-wrapping" />
+        <error line="166" column="59" source="standard:argument-list-wrapping" />
+        <error line="167" column="47" source="standard:wrapping" />
+        <error line="167" column="48" source="standard:argument-list-wrapping" />
+        <error line="167" column="48" source="standard:trailing-comma-on-call-site" />
+        <error line="182" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="182" column="40" source="standard:wrapping" />
+        <error line="182" column="40" source="standard:argument-list-wrapping" />
+        <error line="182" column="59" source="standard:argument-list-wrapping" />
+        <error line="183" column="47" source="standard:wrapping" />
+        <error line="183" column="48" source="standard:argument-list-wrapping" />
+        <error line="183" column="48" source="standard:trailing-comma-on-call-site" />
+        <error line="203" column="56" source="standard:multiline-expression-wrapping" />
+        <error line="205" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="207" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="207" column="40" source="standard:wrapping" />
+        <error line="207" column="40" source="standard:argument-list-wrapping" />
+        <error line="207" column="59" source="standard:argument-list-wrapping" />
+        <error line="208" column="32" source="standard:argument-list-wrapping" />
+        <error line="208" column="66" source="standard:wrapping" />
+        <error line="208" column="67" source="standard:argument-list-wrapping" />
+        <error line="208" column="67" source="standard:trailing-comma-on-call-site" />
+        <error line="223" column="56" source="standard:multiline-expression-wrapping" />
+        <error line="225" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="227" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="227" column="40" source="standard:wrapping" />
+        <error line="227" column="40" source="standard:argument-list-wrapping" />
+        <error line="228" column="48" source="standard:argument-list-wrapping" />
+        <error line="229" column="47" source="standard:wrapping" />
+        <error line="229" column="48" source="standard:argument-list-wrapping" />
+        <error line="229" column="48" source="standard:trailing-comma-on-call-site" />
+        <error line="244" column="56" source="standard:multiline-expression-wrapping" />
+        <error line="246" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="248" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="248" column="40" source="standard:wrapping" />
+        <error line="248" column="40" source="standard:argument-list-wrapping" />
+        <error line="248" column="59" source="standard:argument-list-wrapping" />
+        <error line="249" column="32" source="standard:argument-list-wrapping" />
+        <error line="249" column="66" source="standard:wrapping" />
+        <error line="249" column="67" source="standard:argument-list-wrapping" />
+        <error line="249" column="67" source="standard:trailing-comma-on-call-site" />
+        <error line="264" column="56" source="standard:multiline-expression-wrapping" />
+        <error line="266" column="30" source="standard:trailing-comma-on-call-site" />
+        <error line="268" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="268" column="40" source="standard:wrapping" />
+        <error line="268" column="40" source="standard:argument-list-wrapping" />
+        <error line="268" column="59" source="standard:argument-list-wrapping" />
+        <error line="269" column="32" source="standard:argument-list-wrapping" />
+        <error line="269" column="66" source="standard:wrapping" />
+        <error line="269" column="67" source="standard:argument-list-wrapping" />
+        <error line="269" column="67" source="standard:trailing-comma-on-call-site" />
+        <error line="284" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="287" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="287" column="40" source="standard:wrapping" />
+        <error line="287" column="40" source="standard:argument-list-wrapping" />
+        <error line="288" column="58" source="standard:argument-list-wrapping" />
+        <error line="288" column="92" source="standard:wrapping" />
+        <error line="288" column="93" source="standard:argument-list-wrapping" />
+        <error line="288" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="295" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="298" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="298" column="40" source="standard:wrapping" />
+        <error line="298" column="40" source="standard:argument-list-wrapping" />
+        <error line="299" column="58" source="standard:argument-list-wrapping" />
+        <error line="299" column="92" source="standard:wrapping" />
+        <error line="299" column="93" source="standard:argument-list-wrapping" />
+        <error line="299" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="306" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="309" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="309" column="40" source="standard:wrapping" />
+        <error line="309" column="40" source="standard:argument-list-wrapping" />
+        <error line="310" column="58" source="standard:argument-list-wrapping" />
+        <error line="310" column="92" source="standard:wrapping" />
+        <error line="310" column="93" source="standard:argument-list-wrapping" />
+        <error line="310" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="317" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="320" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="320" column="40" source="standard:wrapping" />
+        <error line="320" column="40" source="standard:argument-list-wrapping" />
+        <error line="321" column="58" source="standard:argument-list-wrapping" />
+        <error line="321" column="92" source="standard:wrapping" />
+        <error line="321" column="93" source="standard:argument-list-wrapping" />
+        <error line="321" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="328" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="331" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="331" column="40" source="standard:wrapping" />
+        <error line="331" column="40" source="standard:argument-list-wrapping" />
+        <error line="332" column="58" source="standard:argument-list-wrapping" />
+        <error line="332" column="92" source="standard:wrapping" />
+        <error line="332" column="93" source="standard:argument-list-wrapping" />
+        <error line="332" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="339" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="342" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="342" column="40" source="standard:wrapping" />
+        <error line="342" column="40" source="standard:argument-list-wrapping" />
+        <error line="343" column="58" source="standard:argument-list-wrapping" />
+        <error line="343" column="92" source="standard:wrapping" />
+        <error line="343" column="93" source="standard:argument-list-wrapping" />
+        <error line="343" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="350" column="39" source="standard:multiline-expression-wrapping" />
+        <error line="353" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="353" column="40" source="standard:wrapping" />
+        <error line="353" column="40" source="standard:argument-list-wrapping" />
+        <error line="354" column="58" source="standard:argument-list-wrapping" />
+        <error line="354" column="92" source="standard:wrapping" />
+        <error line="354" column="93" source="standard:argument-list-wrapping" />
+        <error line="354" column="93" source="standard:trailing-comma-on-call-site" />
+        <error line="357" column="1" source="standard:no-blank-line-before-rbrace" />
+        <error line="358" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/NIDComposeTextWatcherUtilsTest.kt">
+        <error line="73" column="17" source="standard:wrapping" />
+        <error line="73" column="18" source="standard:argument-list-wrapping" />
+        <error line="73" column="18" source="standard:trailing-comma-on-call-site" />
+        <error line="80" column="17" source="standard:wrapping" />
+        <error line="80" column="18" source="standard:argument-list-wrapping" />
+        <error line="80" column="18" source="standard:trailing-comma-on-call-site" />
+        <error line="87" column="17" source="standard:wrapping" />
+        <error line="87" column="18" source="standard:argument-list-wrapping" />
+        <error line="87" column="18" source="standard:trailing-comma-on-call-site" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/NIDEnvironmentProviderTest.kt">
+        <error line="19" column="1" source="standard:no-blank-line-before-rbrace" />
+        <error line="20" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/NIDMetaDataTest.kt">
+        <error line="29" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="177" column="34" source="standard:multiline-expression-wrapping" />
+        <error line="178" column="34" source="standard:argument-list-wrapping" />
+        <error line="179" column="24" source="standard:argument-list-wrapping" />
+        <error line="179" column="39" source="standard:argument-list-wrapping" />
+        <error line="179" column="55" source="standard:argument-list-wrapping" />
+        <error line="180" column="25" source="standard:argument-list-wrapping" />
+        <error line="180" column="40" source="standard:argument-list-wrapping" />
+        <error line="180" column="58" source="standard:argument-list-wrapping" />
+        <error line="556" column="1" source="standard:no-consecutive-blank-lines" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/NIDRuntimeProviderTest.kt">
+        <error line="10" column="41" source="standard:chain-method-continuation" />
+        <error line="10" column="58" source="standard:chain-method-continuation" />
+        <error line="10" column="69" source="standard:chain-method-continuation" />
+        <error line="19" column="41" source="standard:chain-method-continuation" />
+        <error line="19" column="58" source="standard:chain-method-continuation" />
+        <error line="19" column="69" source="standard:chain-method-continuation" />
+        <error line="31" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/NIDSDKVersionTests.kt">
+        <error line="9" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="13" column="16" source="standard:curly-spacing" />
+        <error line="13" column="52" source="standard:curly-spacing" />
+        <error line="14" column="16" source="standard:curly-spacing" />
+        <error line="14" column="46" source="standard:curly-spacing" />
+        <error line="22" column="16" source="standard:curly-spacing" />
+        <error line="22" column="52" source="standard:curly-spacing" />
+        <error line="23" column="16" source="standard:curly-spacing" />
+        <error line="23" column="46" source="standard:curly-spacing" />
+        <error line="31" column="16" source="standard:curly-spacing" />
+        <error line="31" column="52" source="standard:curly-spacing" />
+        <error line="32" column="16" source="standard:curly-spacing" />
+        <error line="32" column="46" source="standard:curly-spacing" />
+        <error line="40" column="16" source="standard:curly-spacing" />
+        <error line="40" column="52" source="standard:curly-spacing" />
+        <error line="41" column="16" source="standard:curly-spacing" />
+        <error line="41" column="46" source="standard:curly-spacing" />
+        <error line="146" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/RootHelperTest.kt">
+        <error line="3" column="1" source="standard:import-ordering" />
+        <error line="5" column="1" source="standard:no-wildcard-imports" />
+        <error line="9" column="1" source="standard:no-wildcard-imports" />
+        <error line="12" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="44" column="16" source="standard:curly-spacing" />
+        <error line="44" column="54" source="standard:curly-spacing" />
+        <error line="45" column="16" source="standard:curly-spacing" />
+        <error line="45" column="76" source="standard:curly-spacing" />
+        <error line="46" column="16" source="standard:curly-spacing" />
+        <error line="46" column="42" source="standard:curly-spacing" />
+        <error line="47" column="16" source="standard:curly-spacing" />
+        <error line="51" column="16" source="standard:curly-spacing" />
+        <error line="51" column="33" source="standard:curly-spacing" />
+        <error line="52" column="16" source="standard:curly-spacing" />
+        <error line="52" column="72" source="standard:curly-spacing" />
+        <error line="53" column="16" source="standard:curly-spacing" />
+        <error line="53" column="55" source="standard:curly-spacing" />
+        <error line="53" column="65" source="standard:multiline-expression-wrapping" />
+        <error line="53" column="70" source="standard:curly-spacing" />
+        <error line="61" column="16" source="standard:curly-spacing" />
+        <error line="61" column="52" source="standard:curly-spacing" />
+        <error line="61" column="62" source="standard:multiline-expression-wrapping" />
+        <error line="61" column="67" source="standard:curly-spacing" />
+        <error line="62" column="20" source="standard:curly-spacing" />
+        <error line="62" column="28" source="standard:curly-spacing" />
+        <error line="77" column="16" source="standard:curly-spacing" />
+        <error line="77" column="54" source="standard:curly-spacing" />
+        <error line="78" column="16" source="standard:curly-spacing" />
+        <error line="78" column="76" source="standard:curly-spacing" />
+        <error line="79" column="16" source="standard:curly-spacing" />
+        <error line="79" column="42" source="standard:curly-spacing" />
+        <error line="80" column="16" source="standard:curly-spacing" />
+        <error line="84" column="16" source="standard:curly-spacing" />
+        <error line="84" column="33" source="standard:curly-spacing" />
+        <error line="85" column="16" source="standard:curly-spacing" />
+        <error line="85" column="72" source="standard:curly-spacing" />
+        <error line="86" column="16" source="standard:curly-spacing" />
+        <error line="86" column="55" source="standard:curly-spacing" />
+        <error line="86" column="65" source="standard:multiline-expression-wrapping" />
+        <error line="86" column="70" source="standard:curly-spacing" />
+        <error line="95" column="16" source="standard:curly-spacing" />
+        <error line="95" column="52" source="standard:curly-spacing" />
+        <error line="95" column="62" source="standard:multiline-expression-wrapping" />
+        <error line="95" column="67" source="standard:curly-spacing" />
+        <error line="96" column="20" source="standard:curly-spacing" />
+        <error line="96" column="28" source="standard:curly-spacing" />
+        <error line="102" column="9" source="standard:comment-spacing" />
+        <error line="109" column="16" source="standard:curly-spacing" />
+        <error line="109" column="54" source="standard:curly-spacing" />
+        <error line="124" column="16" source="standard:curly-spacing" />
+        <error line="124" column="65" source="standard:curly-spacing" />
+        <error line="135" column="16" source="standard:curly-spacing" />
+        <error line="135" column="65" source="standard:curly-spacing" />
+        <error line="142" column="1" source="standard:indent" />
+        <error line="142" column="42" source="standard:parameter-list-wrapping" />
+        <error line="142" column="42" source="standard:wrapping" />
+        <error line="142" column="42" source="standard:function-signature" />
+        <error line="143" column="1" source="standard:indent" />
+        <error line="143" column="35" source="standard:function-signature" />
+        <error line="144" column="1" source="standard:indent" />
+        <error line="144" column="35" source="standard:function-signature" />
+        <error line="145" column="1" source="standard:indent" />
+        <error line="145" column="35" source="standard:function-signature" />
+        <error line="146" column="1" source="standard:indent" />
+        <error line="146" column="35" source="standard:function-signature" />
+        <error line="147" column="1" source="standard:indent" />
+        <error line="147" column="35" source="standard:function-signature" />
+        <error line="148" column="1" source="standard:indent" />
+        <error line="148" column="35" source="standard:function-signature" />
+        <error line="149" column="1" source="standard:indent" />
+        <error line="149" column="35" source="standard:function-signature" />
+        <error line="150" column="1" source="standard:indent" />
+        <error line="150" column="35" source="standard:function-signature" />
+        <error line="150" column="68" source="standard:wrapping" />
+        <error line="150" column="69" source="standard:parameter-list-wrapping" />
+        <error line="150" column="69" source="standard:function-signature" />
+        <error line="150" column="69" source="standard:trailing-comma-on-declaration-site" />
+        <error line="182" column="32" source="standard:trailing-comma-on-call-site" />
+        <error line="222" column="32" source="standard:trailing-comma-on-call-site" />
+        <error line="246" column="26" source="standard:trailing-comma-on-call-site" />
+        <error line="254" column="34" source="standard:trailing-comma-on-call-site" />
+        <error line="262" column="32" source="standard:trailing-comma-on-call-site" />
+        <error line="270" column="32" source="standard:trailing-comma-on-call-site" />
+        <error line="278" column="29" source="standard:trailing-comma-on-call-site" />
+        <error line="286" column="28" source="standard:trailing-comma-on-call-site" />
+        <error line="294" column="28" source="standard:trailing-comma-on-call-site" />
+        <error line="302" column="40" source="standard:trailing-comma-on-call-site" />
+        <error line="310" column="40" source="standard:trailing-comma-on-call-site" />
+        <error line="318" column="27" source="standard:trailing-comma-on-call-site" />
+        <error line="327" column="31" source="standard:trailing-comma-on-call-site" />
+        <error line="368" column="63" source="standard:multiline-expression-wrapping" />
+        <error line="377" column="63" source="standard:multiline-expression-wrapping" />
+        <error line="382" column="1" source="standard:final-newline" />
+    </file>
+    <file name="src/test/java/com/neuroid/tracker/utils/VersionCheckerTest.kt">
+        <error line="21" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="125" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="153" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="172" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="192" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="216" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="254" column="1" source="standard:no-consecutive-blank-lines" />
+    </file>
+</baseline>

--- a/NeuroID/lint-baseline.xml
+++ b/NeuroID/lint-baseline.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.4" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.4)" variant="all" version="8.1.4">
+
+    <issue
+        id="ObsoleteLintCustomCheck"
+        message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.compose.runtime.lint.RuntimeIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/compose/runtime/lint/AutoboxingStateCreationDetector.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`AutoboxingStateValueProperty`&#xA;`AutoboxingStateCreation`&#xA;`CoroutineCreationDuringComposition`&#xA;`FlowOperatorInvokedInComposition`&#xA;`ComposableLambdaParameterNaming`&#xA;`ComposableLambdaParameterPosition`&#xA;`ComposableNaming`&#xA;`StateFlowValueCalledInComposition`&#xA;`CompositionLocalNaming`&#xA;`MutableCollectionMutableState`&#xA;`ProduceStateDoesNotAssignValue`&#xA;`RememberReturnType`&#xA;`OpaqueUnitKey`&#xA;`UnrememberedMutableState`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
+        <location
+            file="$GRADLE_USER_HOME/caches/8.10.2/transforms/bdf49fb2c87eca7d0219c79e1bc2ff28/transformed/jetified-runtime-release/jars/lint.jar"/>
+    </issue>
+
+    <issue
+        id="ObsoleteLintCustomCheck"
+        message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.compose.ui.lint.UiIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/compose/ui/lint/ModifierDeclarationDetectorKt$ensureReceiverIsReferenced$1.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`UnnecessaryComposedModifier`&#xA;`ModifierFactoryExtensionFunction`&#xA;`ModifierFactoryReturnType`&#xA;`ModifierFactoryUnreferencedReceiver`&#xA;`ModifierNodeInspectableProperties`&#xA;`ModifierParameter`&#xA;`MultipleAwaitPointerEventScopes`&#xA;`ReturnFromAwaitPointerEventScope`&#xA;`SuspiciousCompositionLocalModifierRead`&#xA;`SuspiciousModifierThen`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
+        <location
+            file="$GRADLE_USER_HOME/caches/8.10.2/transforms/dfb13e664c516b6e7b9b190b84100917/transformed/jetified-ui-release/jars/lint.jar"/>
+    </issue>
+
+    <issue
+        id="ObsoleteLintCustomCheck"
+        message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.lifecycle.lint.LiveDataCoreIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/lifecycle/lint/NonNullableMutableLiveDataDetector$createUastHandler$1.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`NullSafeMutableLiveData`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
+        <location
+            file="$GRADLE_USER_HOME/caches/8.10.2/transforms/fd90ee23acd0311ac8acd93e94420fc7/transformed/lifecycle-livedata-core-2.8.3/jars/lint.jar"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 34 (current min is 24): `android.Manifest.permission#DETECT_SCREEN_CAPTURE`"
+        errorLine1="                        Manifest.permission.DETECT_SCREEN_CAPTURE,"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/service/NIDScreenCaptureService.kt"
+            line="116"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 34 (current min is 24): `android.app.Activity#unregisterScreenCaptureCallback`"
+        errorLine1="                        activity.unregisterScreenCaptureCallback("
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/service/NIDScreenCaptureService.kt"
+            line="120"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 34 (current min is 24): `android.app.Activity.ScreenCaptureCallback`"
+        errorLine1="                            callback as Activity.ScreenCaptureCallback,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/service/NIDScreenCaptureService.kt"
+            line="121"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 35 (current min is 24): `android.view.WindowManager#removeScreenRecordingCallback`"
+        errorLine1="                        activity.windowManager.removeScreenRecordingCallback("
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/service/NIDScreenCaptureService.kt"
+            line="145"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 35 (current min is 24): `java.util.List#reversed`"
+        errorLine1="                    val result = buildFragAncestry(foundFragment).reversed().joinToString(separator = &quot;/&quot;)"
+        errorLine2="                                                                  ~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt"
+            line="87"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 28 (current min is 24): `android.content.pm.PackageInfo#getLongVersionCode`"
+        errorLine1="                packageInfo.longVersionCode.toInt()"
+        errorLine2="                            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/utils/VersionChecker.kt"
+            line="27"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details."
+        errorLine1="        targetSdk 35"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="60"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.ext:junit than 1.1.3 is available: 1.3.0"
+        errorLine1="}"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="134"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:core-ktx than 1.4.0 is available: 1.7.0"
+        errorLine1=""
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="135"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.espresso:espresso-core than 3.4.0 is available: 3.7.0"
+        errorLine1="dependencies {"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="136"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.json:json than 20140107 is available: 20220320"
+        errorLine1="    testImplementation &quot;androidx.test:core-ktx:1.4.0&quot;"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="139"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.8.0 is available: 1.19.0"
+        errorLine1="    testImplementation &apos;io.mockk:mockk:1.12.0&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="142"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="    testImplementation &apos;org.json:json:20140107&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="143"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-process than 2.4.1 is available: 2.11.0"
+        errorLine1="    implementation &apos;androidx.core:core-ktx:1.8.0&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="146"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.6.1 is available: 1.7.3"
+        errorLine1="    implementation &apos;androidx.appcompat:appcompat:1.7.0&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="147"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlin:kotlin-reflect than 1.7.10 is available: 2.0.21"
+        errorLine1="    implementation &apos;androidx.multidex:multidex:2.0.1&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="149"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui than 1.7.3 is available: 1.11.4"
+        errorLine1=""
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="152"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.facebook.react:react-android than 0.76.9 is available: 0.77.3"
+        errorLine1=""
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="154"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.squareup.okhttp3:okhttp than 4.9.2 is available: 4.12.0"
+        errorLine1=""
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="163"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDynamicVersion"
+        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (junit:junit:4.+)"
+        errorLine1="    }"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="133"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 23"
+        errorLine1="    @RequiresApi(Build.VERSION_CODES.M)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/callbacks/NIDGlobalEventCallback.kt"
+            line="203"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 23"
+        errorLine1="    @RequiresApi(Build.VERSION_CODES.M)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/callbacks/NIDGlobalEventCallback.kt"
+            line="212"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 23"
+        errorLine1="    @RequiresApi(Build.VERSION_CODES.M)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/neuroid/tracker/events/RegistrationIdentificationHelper.kt"
+            line="526"
+            column="5"/>
+    </issue>
+
+</issues>

--- a/NeuroID/src/android/java/com/neuroid/tracker/utils/ExtraUtils.kt
+++ b/NeuroID/src/android/java/com/neuroid/tracker/utils/ExtraUtils.kt
@@ -6,7 +6,7 @@ import com.neuroid.tracker.events.detectBasicAndroidViewType
 import com.neuroid.tracker.events.isCommonAndroidComponent
 
 // Native Android needs to register the activities
-internal fun registrationHelpers(r: Runnable)  {
+internal fun registrationHelpers(r: Runnable) {
     r.run()
 }
 
@@ -15,7 +15,7 @@ fun verifyComponentType(view: View): ComponentValuesResult {
 }
 
 // run the function immediately in native android
-internal fun handleIdentifyAllViews(r: Runnable)  {
+internal fun handleIdentifyAllViews(r: Runnable) {
     r.run()
 }
 
@@ -23,6 +23,4 @@ internal fun detectViewType(currentView: View?): Int {
     return detectBasicAndroidViewType(currentView)
 }
 
-internal fun getEtnSenderName(currentView: View?): String  {
-    return currentView?.javaClass?.simpleName.orEmpty()
-}
+internal fun getEtnSenderName(currentView: View?): String = currentView?.javaClass?.simpleName.orEmpty()

--- a/NeuroID/src/android/java/com/neuroid/tracker/utils/ExtraUtils.kt
+++ b/NeuroID/src/android/java/com/neuroid/tracker/utils/ExtraUtils.kt
@@ -10,17 +10,13 @@ internal fun registrationHelpers(r: Runnable) {
     r.run()
 }
 
-fun verifyComponentType(view: View): ComponentValuesResult {
-    return isCommonAndroidComponent(view)
-}
+fun verifyComponentType(view: View): ComponentValuesResult = isCommonAndroidComponent(view)
 
 // run the function immediately in native android
 internal fun handleIdentifyAllViews(r: Runnable) {
     r.run()
 }
 
-internal fun detectViewType(currentView: View?): Int {
-    return detectBasicAndroidViewType(currentView)
-}
+internal fun detectViewType(currentView: View?): Int = detectBasicAndroidViewType(currentView)
 
 internal fun getEtnSenderName(currentView: View?): String = currentView?.javaClass?.simpleName.orEmpty()

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDRegion.kt
@@ -10,6 +10,6 @@ enum class NIDRegion(
         fpjsProdDomain = "https://advanced.neuro-id.com",
         fpjsPrimaryDomain = "https://dn.neuroid.cloud/iynlfqcb0t",
         productionEndpoint = "https://receiver.neuroid.cloud/",
-        productionScriptsEndpoint = "https://scripts.neuro-id.com/"
-    )
+        productionScriptsEndpoint = "https://scripts.neuro-id.com/",
+    ),
 }

--- a/NeuroID/src/reactNative/java/com/neuroid/tracker/utils/ExtraUtils.kt
+++ b/NeuroID/src/reactNative/java/com/neuroid/tracker/utils/ExtraUtils.kt
@@ -15,7 +15,7 @@ import com.neuroid.tracker.extensions.getSHA256withSalt
 
 // In RN users call registerPageTargets so we don't
 //    want to run this code and double register
-internal fun registrationHelpers(r: Runnable)  {
+internal fun registrationHelpers(r: Runnable) {
 }
 
 fun isCommonReactNativeComponent(view: View): ComponentValuesResult {
@@ -79,7 +79,7 @@ fun verifyComponentType(view: View): ComponentValuesResult {
 }
 
 // run the function after a 300ms delay in react native
-internal fun handleIdentifyAllViews(r: Runnable)  {
+internal fun handleIdentifyAllViews(r: Runnable) {
     android.os.Handler(Looper.getMainLooper()).postDelayed({
         r.run()
     }, 300)
@@ -107,6 +107,4 @@ internal fun detectViewType(currentView: View?): Int {
     return typeOfView
 }
 
-internal fun getEtnSenderName(currentView: View?): String  {
-    return currentView?.getIdOrTag() ?: "main_view"
-}
+internal fun getEtnSenderName(currentView: View?): String = currentView?.getIdOrTag() ?: "main_view"

--- a/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
+++ b/NeuroID/src/testReactNative/java/com/neuroid/tracker/extensions/NIDRNBuilderTest.kt
@@ -16,7 +16,7 @@ class NIDRNBuilderTest {
     fun testRNOption_no_options_set() {
         val mockApp = mockk<Application>()
         val options = mockk<ReadableMap>()
-        every {options.hasKey(any())} returns false
+        every { options.hasKey(any()) } returns false
         val t = NIDRNBuilder(mockApp, "dummy_key", options)
         val mapOptions = t.parseOptions(options)
         assertFalse(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean)
@@ -31,18 +31,18 @@ class NIDRNBuilderTest {
     fun testRNOption_environment_isAdvancedDevice_options_set() {
         val mockApp = mockk<Application>()
         val options = mockk<ReadableMap>()
-        every {options.hasKey(RNConfigOptions.isAdvancedDevice.name)} returns true
-        every {options.hasKey(RNConfigOptions.environment.name)} returns true
-        every {options.hasKey(RNConfigOptions.advancedDeviceKey.name)} returns true
-        every {options.hasKey(RNConfigOptions.useAdvancedDeviceProxy.name)} returns true
-        every {options.hasKey( RNConfigOptions.rnVersion.name)} returns true
-        every {options.hasKey(RNConfigOptions.region.name)} returns true
-        every {options.getBoolean(RNConfigOptions.isAdvancedDevice.name)} returns true
-        every {options.getString(RNConfigOptions.advancedDeviceKey.name)} returns "testkey"
-        every {options.getBoolean(RNConfigOptions.useAdvancedDeviceProxy.name)} returns false
-        every {options.getString(RNConfigOptions.environment.name)} returns NeuroID.PRODSCRIPT_DEVCOLLECTION
-        every {options.getString(RNConfigOptions.rnVersion.name)} returns "0.71.0"
-        every {options.getString(RNConfigOptions.region.name)} returns NIDRegion.usWest.name
+        every { options.hasKey(RNConfigOptions.isAdvancedDevice.name) } returns true
+        every { options.hasKey(RNConfigOptions.environment.name) } returns true
+        every { options.hasKey(RNConfigOptions.advancedDeviceKey.name) } returns true
+        every { options.hasKey(RNConfigOptions.useAdvancedDeviceProxy.name) } returns true
+        every { options.hasKey(RNConfigOptions.rnVersion.name) } returns true
+        every { options.hasKey(RNConfigOptions.region.name) } returns true
+        every { options.getBoolean(RNConfigOptions.isAdvancedDevice.name) } returns true
+        every { options.getString(RNConfigOptions.advancedDeviceKey.name) } returns "testkey"
+        every { options.getBoolean(RNConfigOptions.useAdvancedDeviceProxy.name) } returns false
+        every { options.getString(RNConfigOptions.environment.name) } returns NeuroID.PRODSCRIPT_DEVCOLLECTION
+        every { options.getString(RNConfigOptions.rnVersion.name) } returns "0.71.0"
+        every { options.getString(RNConfigOptions.region.name) } returns NIDRegion.usWest.name
         val t = NIDRNBuilder(mockApp, "dummy_key", options)
         val mapOptions = t.parseOptions(options)
         assertTrue(mapOptions[RNConfigOptions.isAdvancedDevice] as Boolean)
@@ -94,4 +94,3 @@ class NIDRNBuilderTest {
         assertEquals(NIDRegion.usWest.name, mapOptions[RNConfigOptions.region] as String)
     }
 }
-

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ For support or troubleshooting of the NeuroID Android Mobile SDK please contact 
 
 For a feature request in the NeuroID Android Mobile SDK please contact a NeuroID Customer Support Representative.
 
+### Local development setup
+
+After cloning, install the repo's git hooks so `ktlint` style violations are caught before you push (the same check runs in CI on every PR):
+
+```bash
+bash scripts/setup-git-hooks.sh
+```
+
+This registers a `pre-commit` hook that runs `./gradlew :NeuroID:ktlintCheck` automatically whenever a commit touches `NeuroID/**/*.kt` files.
+
 ## License
 
 The NeuroID Android Mobile SDK is provided under an [MIT License](LICENSE).

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     ext.kotlin_version = "1.9.24"
     dependencies {
@@ -13,6 +14,7 @@ buildscript {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.2"
         classpath('com.google.dagger:hilt-android-gradle-plugin:2.48')
         classpath "org.jacoco:org.jacoco.core:0.8.12"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.1"
     }
 }
 

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# One-time setup: point git at the repo's tracked hooks directory.
+# Run this once after cloning: bash scripts/setup-git-hooks.sh
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+chmod +x "$REPO_ROOT/.githooks/pre-commit"
+git -C "$REPO_ROOT" config core.hooksPath .githooks
+
+echo "Git hooks installed. pre-commit will now run ktlintCheck on staged NeuroID/*.kt files."
+


### PR DESCRIPTION
KTLint will run on PR creation and fail build if ktlint doesn't pass. 

Kotlin style check (ktlint)

`./gradlew :NeuroID:ktlintCheck`

Android Lint - android flavour

`./gradlew :NeuroID:lintAndroidLibDebug`

Android Lint - reactNative flavour

`./gradlew :NeuroID:lintReactNativeLibDebug`

build.gradle contains the baseline configuration: 

```
 ktlint {
       version.set("1.3.1")   // pins the ktlint engine version used
       android.set(true)      // enables the Android Kotlin style guide variant of the standard ruleset
       ignoreFailures.set(false)
       outputToConsole.set(true)
       baseline.set(file("config/ktlint/baseline.xml"))  // grandfathers pre-existing violations
       filter { ... }
   }
```

Also local commits will run the ktlink check prior to commit. 
```
➜  neuroid-android-sdk git:(ENG-11725-formatting-linting) ✗ git commit -e
Running ktlintCheck on NeuroID module before commit...
✅ ktlint check passed.
[ENG-11725-formatting-linting 16586ce] ENG-11725 update for lint
 1 file changed, 3 insertions(+), 3 deletions(-)
```
Please install the repo's git hooks so `ktlint` style violations are caught before you push (the same check runs in CI on every PR):

```bash
bash scripts/setup-git-hooks.sh
```

This registers a `pre-commit` hook that runs `./gradlew :NeuroID:ktlintCheck` automatically whenever a commit touches `NeuroID/**/*.kt` files.

