### PR TITLE
[ENG-12000] Ensure SDK version is present in early packets

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
@@ -11,6 +11,7 @@ import com.neuroid.tracker.models.NIDResponseCallBack
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
 import com.neuroid.tracker.utils.NIDLog
 import com.neuroid.tracker.utils.NIDTime
+import com.neuroid.tracker.utils.NIDVersion
 import com.neuroid.tracker.utils.generateUniqueHexID
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -130,7 +131,7 @@ class NIDEventSender(
                 "responseId" to generateUniqueHexID(),
                 "url" to "$ANDROID_URI${NeuroID.screenActivityName}",
                 "jsVersion" to "5.0.0",
-                "sdkVersion" to NeuroID.getInstance()?.getSDKVersion(),
+                "sdkVersion" to NIDVersion.getSDKVersion(),
                 "environment" to NeuroID.environment,
                 "jsonEvents" to events,
                 "linkedSiteId" to linkedSiteID,

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDSessionService.kt
@@ -13,6 +13,7 @@ import com.neuroid.tracker.models.SessionStartResult
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
 import com.neuroid.tracker.utils.NIDLogWrapper
 import com.neuroid.tracker.utils.NIDSingletonIDs
+import com.neuroid.tracker.utils.NIDVersion
 import com.neuroid.tracker.utils.generateUniqueHexID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -411,7 +412,7 @@ internal class NIDSessionService(
                 dnt = false,
                 url = "",
                 ns = "nid",
-                jsv = NeuroID.getInstance()?.getSDKVersion(),
+                jsv = NIDVersion.getSDKVersion(),
                 sw = sharedPreferenceDefaults.getDisplayWidth().toFloat(),
                 sh = sharedPreferenceDefaults.getDisplayHeight().toFloat(),
                 metadata = neuroID.metaData,


### PR DESCRIPTION
Ensure the SDK version is included in early network packets by using `NIDVersion.getSDKVersion()` instead of `NeuroID.getInstance()?.getSDKVersion()`, which may be null before the NeuroID singleton initializes. This addresses a bug where `sdkVersion` may be null in early event packets.

[ENG-12000]

[ENG-12000]: https://neuro-id.atlassian.net/browse/ENG-12000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ