### PR TITLE
[ENG-12110] Deprecate separate advanced device functions

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.runBlocking
 
 @Deprecated(
     "Use start(completion) instead",
-    ReplaceWith("start(completion)")
+    ReplaceWith("start(completion)"),
 )
 fun NeuroIDPublic.start(
     advancedDeviceSignals: Boolean,
@@ -50,7 +50,7 @@ fun NeuroIDPublic.start(
  */
 @Deprecated(
     "Use startSession(sessionID, completion) instead",
-    ReplaceWith("startSession(sessionID, completion)")
+    ReplaceWith("startSession(sessionID, completion)"),
 )
 fun NeuroIDPublic.startSession(
     sessionID: String? = null,

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -21,6 +21,11 @@ import kotlinx.coroutines.runBlocking
  * enable/disable the advanced signal collection. Return true to indicate that the SDK is started.
  * Return false if not started.
  */
+
+@Deprecated(
+    "Use start(completion) instead",
+    ReplaceWith("start(completion)")
+)
 fun NeuroIDPublic.start(
     advancedDeviceSignals: Boolean,
     completion: (Boolean) -> Unit = {},
@@ -43,6 +48,10 @@ fun NeuroIDPublic.start(
  * indicating the started state of the SDK. Takes in a boolean to
  * enable/disable the advanced signal collection.
  */
+@Deprecated(
+    "Use startSession(sessionID, completion) instead",
+    ReplaceWith("startSession(sessionID, completion)")
+)
 fun NeuroIDPublic.startSession(
     sessionID: String? = null,
     advancedDeviceSignals: Boolean,


### PR DESCRIPTION
Deprecate separate advanced device functions:
- `start(advancedDeviceSignals, completion)`
- `startSession(sessionID, advancedDeviceSignals, completion)`

[ENG-12110]

[ENG-12110]: https://neuro-id.atlassian.net/browse/ENG-12110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ