### PR TITLE
[ENG-12101] Cleanup D+N Service

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -30,15 +30,18 @@ import com.neuroid.tracker.events.SET_LINKED_SITE
 import com.neuroid.tracker.events.SET_REGISTERED_USER_ID
 import com.neuroid.tracker.events.SET_USER_ID
 import com.neuroid.tracker.events.SET_VARIABLE
-import com.neuroid.tracker.extensions.captureAdvancedDevice
 import com.neuroid.tracker.models.NIDConfiguration
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.models.NIDRegion
 import com.neuroid.tracker.models.NIDSensorModel
 import com.neuroid.tracker.models.NIDTouchModel
 import com.neuroid.tracker.models.SessionStartResult
+import com.neuroid.tracker.service.AdvancedDeviceIDManager
+import com.neuroid.tracker.service.AdvancedDeviceIDManagerService
 import com.neuroid.tracker.service.ConfigService
 import com.neuroid.tracker.service.HttpService
+import com.neuroid.tracker.service.NIDAdvancedDeviceApiService
+import com.neuroid.tracker.service.NIDAdvancedDeviceNetworkService
 import com.neuroid.tracker.service.NIDCallActivityListener
 import com.neuroid.tracker.service.NIDConfigService
 import com.neuroid.tracker.service.NIDHttpService
@@ -65,11 +68,10 @@ import com.neuroid.tracker.utils.VersionChecker
 import com.neuroid.tracker.utils.generateUniqueHexID
 import com.neuroid.tracker.utils.getAppMetaData
 import com.neuroid.tracker.utils.getGUID
+import com.neuroid.tracker.utils.getRetroFitInstance
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import org.jetbrains.annotations.TestOnly
 import kotlin.Deprecated
 import kotlin.ReplaceWith
@@ -85,6 +87,7 @@ class NeuroID
     ) : NeuroIDPublic {
         @Volatile internal var pauseCollectionJob: Job? = null // internal only for testing purposes
 
+        private val appContext = application?.applicationContext
         private var firstTime = true
         internal var clientID = ""
 
@@ -109,6 +112,7 @@ class NeuroID
         internal var randomGenerator = RandomGenerator()
         internal var logger: NIDLogWrapper = NIDLogWrapper()
         internal var configService: ConfigService
+        internal var deviceNetworkService: AdvancedDeviceIDManagerService? = null
         internal var dataStore: NIDDataStoreManager
         internal var registrationIdentificationHelper: RegistrationIdentificationHelper
         internal var nidActivityCallbacks: ActivityCallbacks
@@ -175,6 +179,34 @@ class NeuroID
 
             configService = NIDConfigService(dispatcher, logger, httpService, validationService)
             dataStore = NIDDataStoreManagerImp(logger, configService)
+
+            val advNetworkService = NIDAdvancedDeviceNetworkService(
+                getRetroFitInstance(
+                    endpoint,
+                    logger,
+                    NIDAdvancedDeviceApiService::class.java,
+                    NIDAdvancedDeviceNetworkService.TIMEOUT,
+                ),
+                logger,
+            )
+
+            appContext?.let { context ->
+                deviceNetworkService =
+                    AdvancedDeviceIDManager(
+                        context,
+                        logger,
+                        NIDSharedPrefsDefaults(context),
+                        this,
+                        advNetworkService,
+                        this.clientID,
+                        this.linkedSiteID ?: "",
+                        configService,
+                        advancedDeviceKey,
+                        fpjsClientOverride,
+                        useAdvancedDeviceProxy = useAdvancedDeviceProxy,
+                        region = region,
+                    )
+            }
 
             identifierService =
                 NIDIdentifierService(
@@ -541,12 +573,9 @@ class NeuroID
         }
 
         internal fun checkThenCaptureAdvancedDevice(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-            CoroutineScope(dispatcher).launch {
-                captureAdvancedDevice(
-                    advancedDeviceKey,
-                    useAdvancedDeviceProxy,
-                    region,
-                )
+            captureEvent(queuedEvent = true, type = LOG, m = "shouldCapture setting: $isAdvancedDevice", level = "INFO")
+            if (configService.isSessionFlowSampled()) {
+                deviceNetworkService?.captureAdvancedDevice(clientKey)
             }
         }
 

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -574,7 +574,10 @@ class NeuroID
 
         internal fun checkThenCaptureAdvancedDevice() {
             captureEvent(queuedEvent = true, type = LOG, m = "shouldCapture setting: $isAdvancedDevice", level = "INFO")
-            deviceNetworkService?.captureAdvancedDevice(clientKey)
+            // If we are not sampling this session, we should not capture the adv device signals
+            if (configService.isSessionFlowSampled()) {
+                deviceNetworkService?.captureAdvancedDevice(clientKey)
+            }
         }
 
         override fun setScreenName(screen: String): Boolean {

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -182,7 +182,7 @@ class NeuroID
 
             val advNetworkService = NIDAdvancedDeviceNetworkService(
                 getRetroFitInstance(
-                    endpoint,
+                    region.productionEndpoint,
                     logger,
                     NIDAdvancedDeviceApiService::class.java,
                     NIDAdvancedDeviceNetworkService.TIMEOUT,
@@ -572,7 +572,7 @@ class NeuroID
             return true
         }
 
-        internal fun checkThenCaptureAdvancedDevice(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+        internal fun checkThenCaptureAdvancedDevice() {
             captureEvent(queuedEvent = true, type = LOG, m = "shouldCapture setting: $isAdvancedDevice", level = "INFO")
             if (configService.isSessionFlowSampled()) {
                 deviceNetworkService?.captureAdvancedDevice(clientKey)

--- a/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/NeuroID.kt
@@ -574,9 +574,7 @@ class NeuroID
 
         internal fun checkThenCaptureAdvancedDevice() {
             captureEvent(queuedEvent = true, type = LOG, m = "shouldCapture setting: $isAdvancedDevice", level = "INFO")
-            if (configService.isSessionFlowSampled()) {
-                deviceNetworkService?.captureAdvancedDevice(clientKey)
-            }
+            deviceNetworkService?.captureAdvancedDevice(clientKey)
         }
 
         override fun setScreenName(screen: String): Boolean {

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/AdvancedDeviceExtension.kt
@@ -1,21 +1,7 @@
 package com.neuroid.tracker.extensions
 
-import com.neuroid.tracker.NeuroID
-import com.neuroid.tracker.NeuroID.Companion.fpjsClientOverride
 import com.neuroid.tracker.NeuroIDPublic
-import com.neuroid.tracker.events.LOG
-import com.neuroid.tracker.models.NIDRegion
 import com.neuroid.tracker.models.SessionStartResult
-import com.neuroid.tracker.service.AdvancedDeviceIDManager
-import com.neuroid.tracker.service.AdvancedDeviceIDManagerService
-import com.neuroid.tracker.service.getADVNetworkService
-import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 /**
  * Start the SDK and start a new session using the userID as the sessionID. Takes in a boolean to
@@ -57,59 +43,4 @@ fun NeuroIDPublic.startSession(
     ) {
         completion(it)
     }
-}
-
-@Synchronized
-fun NeuroID.captureAdvancedDevice(
-    advancedDeviceKey: String?,
-    useAdvancedDeviceProxy: Boolean,
-    region: NIDRegion = NIDRegion.usWest,
-) = runBlocking {
-    captureEvent(queuedEvent = true, type = LOG, m = "shouldCapture setting: $isAdvancedDevice", level = "INFO")
-    NeuroID.getInternalInstance()?.apply {
-        getApplicationContext()?.let { context ->
-            val advancedDeviceIDManagerService =
-                AdvancedDeviceIDManager(
-                    context,
-                    logger,
-                    NIDSharedPrefsDefaults(context),
-                    this,
-                    getADVNetworkService(
-                        region.productionEndpoint,
-                        logger,
-                    ),
-                    this.clientID,
-                    this.linkedSiteID ?: "",
-                    configService,
-                    advancedDeviceKey,
-                    fpjsClientOverride,
-                    useAdvancedDeviceProxy = useAdvancedDeviceProxy,
-                    region = region,
-                )
-            getADVSignal(advancedDeviceIDManagerService, clientKey, this)?.join()
-        }
-    }
-
-    // runBlocking returns the value of its last expression, adding an explicit Unit at the end of the runBlocking block anchors the return type to Unit unconditionally
-    Unit
-}
-
-internal fun getADVSignal(
-    advancedDeviceIDManagerService: AdvancedDeviceIDManagerService,
-    clientKey: String,
-    neuroID: NeuroID,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
-): Job? {
-    var job: Job? = null
-    // do this in the background off main but wait for it to complete
-    if (neuroID.configService.isSessionFlowSampled()) {
-        job = CoroutineScope(dispatcher).launch {
-            // check for cachedID first
-            if (!advancedDeviceIDManagerService.getCachedID()) {
-                // no cached ID - contact NID & FPJS
-                advancedDeviceIDManagerService.getRemoteID(clientKey)?.join()
-            }
-        }
-    }
-    return job
 }

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDTextExtensions.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDTextExtensions.kt
@@ -3,17 +3,6 @@ package com.neuroid.tracker.extensions
 import com.neuroid.tracker.utils.NIDSingletonIDs
 import java.security.MessageDigest
 
-fun String.getSHA256(): String {
-    if (this.isBlank()) {
-        return ""
-    }
-    val bytes = this.toByteArray()
-    val md = MessageDigest.getInstance("SHA-256")
-    val digest = md.digest(bytes)
-
-    return digest.fold("") { str, it -> str + "%02x".format(it) }
-}
-
 fun String.getSHA256withSalt(): String {
     val saltedValue = NIDSingletonIDs.getSalt() + this
     return if (saltedValue.isBlank()) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt
@@ -7,7 +7,6 @@ import android.content.res.Resources
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import com.neuroid.tracker.utils.NIDLogWrapper
 
 fun View?.getIdOrTag(): String {
     return if (this == null) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/extensions/NIDViewsExtensions.kt
@@ -39,26 +39,6 @@ fun View.getRandomId(): String {
     return "${this.javaClass.simpleName}_$viewCoordinates"
 }
 
-fun View.getParents(logger: NIDLogWrapper): String = getParentsOfView(0, this, logger)
-
-fun View.getParentsOfView(
-    layers: Int,
-    view: View,
-    log: NIDLogWrapper,
-): String {
-    return if (view.parent is View) {
-        val childView = view.parent as View
-        if (layers == 3 || childView.id == android.R.id.content) {
-            ""
-        } else {
-            "${childView.javaClass.simpleName}/${getParentsOfView(layers + 1, childView, log)}"
-        }
-    } else {
-        log.e(msg = "instance ${view.parent?.javaClass?.name} is not a view!")
-        "not_a_view"
-    }
-}
-
 fun View.getParentActivity(): String? {
     var context: Context? = this.context
     while (context is Context) {

--- a/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/NIDEventModel.kt
@@ -233,6 +233,25 @@ data class NIDEventModel(
     }
 }
 
+data class EventBundle(
+    val siteId: String? = null,
+    val userId: String? = null,
+    val clientId: String? = null,
+    val identityId: String? = null,
+    val registeredUserId: String? = null,
+    val pageTag: String? = null,
+    val pageId: String? = null,
+    val tabId: String? = null,
+    val responseId: String? = null,
+    val url: String? = null,
+    val jsVersion: String = "5.0.0",
+    val sdkVersion: String? = null,
+    val environment: String? = null,
+    val jsonEvents: List<NIDEventModel> = emptyList(),
+    val linkedSiteId: String? = null,
+    val packetNumber: Int = -1,
+)
+
 data class NIDSensorModel(
     val x: Float?,
     val y: Float?,

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
@@ -31,6 +31,8 @@ interface AdvancedDeviceIDManagerService {
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         delay: Long = 5000L,
     ): Job?
+
+    fun captureAdvancedDevice(clientKey: String)
 }
 
 internal class AdvancedDeviceIDManager(
@@ -52,6 +54,16 @@ internal class AdvancedDeviceIDManager(
     companion object {
         internal val NID_RID = "NID_RID_KEY"
         internal val defaultCacheValue = "{\"key\":\"NO_KEY\", \"exp\":0}"
+    }
+
+    override fun captureAdvancedDevice(clientKey: String) {
+        // check for cachedID first
+        if (getCachedID()) {
+            return
+        }
+
+        // no cached ID - contact NID & FPJS
+        getRemoteID(clientKey)
     }
 
     override fun getCachedID(): Boolean {

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/AdvancedDeviceIDManagerService.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlin.text.get
 
 interface AdvancedDeviceIDManagerService {
     fun getCachedID(): Boolean
@@ -84,11 +85,6 @@ internal class AdvancedDeviceIDManager(
             return false
         }
 
-        // Capture valid cached ID
-        logger.d(
-            msg =
-                "Retrieving Request ID for Advanced Device Signals from cache: ${storedValue["key"]}",
-        )
         neuroID.captureEvent(
             queuedEvent = true,
             type = ADVANCED_DEVICE_REQUEST,
@@ -140,15 +136,12 @@ internal class AdvancedDeviceIDManager(
         // if not, get it from server
         var fpjsRetrievedKey = ""
         if (advancedDeviceKey.isNullOrEmpty()) {
-            val keyFunctionResponse = getAdvancedDeviceKey(clientKey)
+            val apiKey = getAdvancedDeviceKey(clientKey)
             // if server gotten FPJS key is null or empty exit immediately
-            if (keyFunctionResponse == null) {
+            apiKey?.let {
+                fpjsRetrievedKey = it.key
+            } ?: run {
                 return null
-            } else {
-                // set the key for use later if successfully gotten from server.
-                keyFunctionResponse?.let {
-                    fpjsRetrievedKey = keyFunctionResponse.key
-                }
             }
         }
 
@@ -175,7 +168,7 @@ internal class AdvancedDeviceIDManager(
                 var jobErrorMessage = ""
                 for (retryCount in 1..maxRetryCount) {
                     // we want to see the latency from FPJS on each request
-                    val startTime = nidTime.getCurrentTimeMillis()
+                    val startTime = System.currentTimeMillis()
                     // returns a Bool - success, String - key OR error message
                     val requestResponse = getVisitorId(fpjsClient)
                     // If Success - capture ID and cache, end loop
@@ -185,12 +178,12 @@ internal class AdvancedDeviceIDManager(
                                 "Generating Request ID for Advanced Device Signals: ${requestResponse.second}",
                         )
 
-                        val stopTime = nidTime.getCurrentTimeMillis()
+                        val stopTime = System.currentTimeMillis()
                         neuroID.captureEvent(
                             queuedEvent = true,
                             type = ADVANCED_DEVICE_REQUEST,
                             rid = requestResponse.second,
-                            ts = nidTime.getCurrentTimeMillis(),
+                            ts = System.currentTimeMillis(),
                             c = false,
                             // time start to end time
                             l = stopTime - startTime,

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDAdvancedDeviceNetworkService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDAdvancedDeviceNetworkService.kt
@@ -4,7 +4,6 @@ import com.neuroid.tracker.models.ADVKeyFunctionResponse
 import com.neuroid.tracker.models.ADVKeyNetworkResponse
 import com.neuroid.tracker.utils.Base64Decoder
 import com.neuroid.tracker.utils.NIDLogWrapper
-import com.neuroid.tracker.utils.getRetroFitInstance
 import retrofit2.Call
 
 interface ADVNetworkService {

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDAdvancedDeviceNetworkService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDAdvancedDeviceNetworkService.kt
@@ -120,17 +120,3 @@ class NIDAdvancedDeviceNetworkService(
         }
     }
 }
-
-fun getADVNetworkService(
-    endpoint: String,
-    logger: NIDLogWrapper,
-): ADVNetworkService =
-    NIDAdvancedDeviceNetworkService(
-        getRetroFitInstance(
-            endpoint,
-            logger,
-            NIDAdvancedDeviceApiService::class.java,
-            NIDAdvancedDeviceNetworkService.TIMEOUT,
-        ),
-        logger,
-    )

--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDEventSender.kt
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.events.ANDROID_URI
 import com.neuroid.tracker.events.OUT_OF_MEMORY
+import com.neuroid.tracker.models.EventBundle
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.models.NIDResponseCallBack
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
@@ -113,38 +114,36 @@ class NIDEventSender(
             }
         val packetNumber: Int = NeuroID.getInternalInstance()?.packetNumber ?: 0
 
-        val jsonBody =
-            mapOf(
-                "siteId" to NeuroID.siteID,
-                "userId" to userID,
-                "clientId" to sharedDefaults.getClientID(),
-                "identityId" to userID,
-                "registeredUserId" to registeredUserID,
-                "pageTag" to NeuroID.screenActivityName,
-                "pageId" to NeuroID.rndmId,
-                "tabId" to tabID,
-                "responseId" to generateUniqueHexID(),
-                "url" to "$ANDROID_URI${NeuroID.screenActivityName}",
-                "jsVersion" to "5.0.0",
-                "sdkVersion" to NIDVersion.getSDKVersion(),
-                "environment" to NeuroID.environment,
-                "jsonEvents" to events,
-                "linkedSiteId" to linkedSiteID,
-                "packetNumber" to packetNumber,
-            )
+        val bundle = EventBundle(
+            siteId = NeuroID.siteID,
+            userId = userID,
+            clientId = sharedDefaults.getClientID(),
+            identityId = userID,
+            registeredUserId = registeredUserID,
+            pageTag = NeuroID.screenActivityName,
+            pageId = NeuroID.rndmId,
+            tabId = tabID,
+            responseId = generateUniqueHexID(),
+            url = "$ANDROID_URI${NeuroID.screenActivityName}",
+            sdkVersion = NIDVersion.getSDKVersion(),
+            environment = NeuroID.environment,
+            jsonEvents = events,
+            linkedSiteId = linkedSiteID,
+            packetNumber = packetNumber,
+        )
 
         NIDLog.d(
             "Payload:",
             msg =
                 """
                 Payload Summary
-                ClientID: ${jsonBody["clientId"]}
-                UserID: ${jsonBody["userId"]}
-                RegisteredUserID: ${jsonBody["registeredUserId"]}
-                LinkedSiteID: ${jsonBody["linkedSiteId"]}
-                TabID: ${jsonBody["tabId"]}
-                Packet Number: ${jsonBody["packetNumber"]}
-                SDK Version: ${jsonBody["sdkVersion"]}
+                ClientID: ${bundle.clientId}
+                UserID: ${bundle.userId}
+                RegisteredUserID: ${bundle.registeredUserId}
+                LinkedSiteID: ${bundle.linkedSiteId}
+                TabID: ${bundle.tabId}
+                Packet Number: ${bundle.packetNumber}
+                SDK Version: ${bundle.sdkVersion}
                 Screen Name: ${NeuroID.screenName}
                 Event Count: ${events.size}
                 """.trimIndent(),
@@ -153,7 +152,7 @@ class NIDEventSender(
         // using this JSON library (already included) does not escape /
         NIDLog.i(msg = "NID logging events (${events.count()}) as linkedSiteID: $linkedSiteID")
         val gson: Gson = GsonBuilder().create()
-        return gson.toJson(jsonBody)
+        return gson.toJson(bundle)
     }
 }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
@@ -13,13 +13,11 @@ import com.fingerprintjs.android.fpjs_pro.FingerprintJSProResponse
 import com.neuroid.tracker.callbacks.NIDSensorGenListener
 import com.neuroid.tracker.events.ADVANCED_DEVICE_REQUEST
 import com.neuroid.tracker.events.LOG
-import com.neuroid.tracker.extensions.getADVSignal
 import com.neuroid.tracker.models.ADVKeyFunctionResponse
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.service.ADVNetworkService
 import com.neuroid.tracker.service.AdvancedDeviceIDManager
 import com.neuroid.tracker.service.AdvancedDeviceIDManagerService
-import com.neuroid.tracker.service.ConfigService
 import com.neuroid.tracker.service.NIDAdvancedDeviceNetworkService
 import com.neuroid.tracker.storage.NIDDataStoreManager
 import com.neuroid.tracker.storage.NIDSharedPrefsDefaults
@@ -44,29 +42,30 @@ class AdvancedDeviceIDManagerServiceTest {
     /*
      TESTS
      */
-    @Test
-    fun testGetADVSignal_is_sampled_true() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
-        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
-        val mockedNIDConfigService = mockk<ConfigService>()
-        every { mockedNIDConfigService.isSessionFlowSampled() } returns true
-        every { mockedNeuroID.configService } returns mockedNIDConfigService
-        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
-        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
-        verify(exactly = 1) { advancedDeviceIDManagerService.getCachedID() }
-    }
-
-    @Test
-    fun testGetADVSignal_is_sampled_false() {
-        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
-        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
-        val mockedNIDConfigService = mockk<ConfigService>()
-        every { mockedNIDConfigService.isSessionFlowSampled() } returns false
-        every { mockedNeuroID.configService } returns mockedNIDConfigService
-        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
-        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
-        verify(exactly = 0) { advancedDeviceIDManagerService.getCachedID() }
-    }
+    // We do want to check sampling, because if it's disabled then we don't want to do extra requests, because then we'll just throw the event away
+//    @Test
+//    fun testGetADVSignal_is_sampled_true() {
+//        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
+//        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
+//        val mockedNIDConfigService = mockk<ConfigService>()
+//        every { mockedNIDConfigService.isSessionFlowSampled() } returns true
+//        every { mockedNeuroID.configService } returns mockedNIDConfigService
+//        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
+//        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
+//        verify(exactly = 1) { advancedDeviceIDManagerService.getCachedID() }
+//    }
+//
+//    @Test
+//    fun testGetADVSignal_is_sampled_false() {
+//        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
+//        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
+//        val mockedNIDConfigService = mockk<ConfigService>()
+//        every { mockedNIDConfigService.isSessionFlowSampled() } returns false
+//        every { mockedNeuroID.configService } returns mockedNIDConfigService
+//        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
+//        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
+//        verify(exactly = 0) { advancedDeviceIDManagerService.getCachedID() }
+//    }
 
     //    getCachedID
     @Test

--- a/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
@@ -42,31 +42,6 @@ class AdvancedDeviceIDManagerServiceTest {
     /*
      TESTS
      */
-    // We do want to check sampling, because if it's disabled then we don't want to do extra requests, because then we'll just throw the event away
-//    @Test
-//    fun testGetADVSignal_is_sampled_true() {
-//        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
-//        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
-//        val mockedNIDConfigService = mockk<ConfigService>()
-//        every { mockedNIDConfigService.isSessionFlowSampled() } returns true
-//        every { mockedNeuroID.configService } returns mockedNIDConfigService
-//        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
-//        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
-//        verify(exactly = 1) { advancedDeviceIDManagerService.getCachedID() }
-//    }
-//
-//    @Test
-//    fun testGetADVSignal_is_sampled_false() {
-//        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
-//        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
-//        val mockedNIDConfigService = mockk<ConfigService>()
-//        every { mockedNIDConfigService.isSessionFlowSampled() } returns false
-//        every { mockedNeuroID.configService } returns mockedNIDConfigService
-//        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
-//        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
-//        verify(exactly = 0) { advancedDeviceIDManagerService.getCachedID() }
-//    }
-
     //    getCachedID
     @Test
     fun testGetCachedID_not_stored() {

--- a/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AdvancedDeviceIDManagerServiceTest.kt
@@ -42,6 +42,31 @@ class AdvancedDeviceIDManagerServiceTest {
     /*
      TESTS
      */
+    // We do want to check sampling, because if it's disabled then we don't want to do extra requests, because then we'll just throw the event away
+//    @Test
+//    fun testGetADVSignal_is_sampled_true() {
+//        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
+//        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
+//        val mockedNIDConfigService = mockk<ConfigService>()
+//        every { mockedNIDConfigService.isSessionFlowSampled() } returns true
+//        every { mockedNeuroID.configService } returns mockedNIDConfigService
+//        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
+//        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
+//        verify(exactly = 1) { advancedDeviceIDManagerService.getCachedID() }
+//    }
+//
+//    @Test
+//    fun testGetADVSignal_is_sampled_false() {
+//        val mocks = buildAdvancedDeviceIDManagerService_noUserSetAdvancedKey("")
+//        val mockedNeuroID = mocks.get("mockedNeuroID") as NeuroID
+//        val mockedNIDConfigService = mockk<ConfigService>()
+//        every { mockedNIDConfigService.isSessionFlowSampled() } returns false
+//        every { mockedNeuroID.configService } returns mockedNIDConfigService
+//        val advancedDeviceIDManagerService = mocks["advancedDeviceIDManagerService"] as AdvancedDeviceIDManagerService
+//        getADVSignal(advancedDeviceIDManagerService, "dummy_key", mockedNeuroID, Dispatchers.Unconfined)
+//        verify(exactly = 0) { advancedDeviceIDManagerService.getCachedID() }
+//    }
+
     //    getCachedID
     @Test
     fun testGetCachedID_not_stored() {

--- a/NeuroID/src/test/java/com/neuroid/tracker/AndroidTestUtils.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/AndroidTestUtils.kt
@@ -76,7 +76,7 @@ internal fun getMockedNeuroID(
     every { nidMock.forceStart } returns forceStart
     every { nidMock.shouldForceStart() } returns forceStart
 
-    every { nidMock.checkThenCaptureAdvancedDevice(any()) } just runs
+    every { nidMock.checkThenCaptureAdvancedDevice() } just runs
     every { nidMock.captureApplicationMetaData() } just runs
     every { nidMock.metaData } returns null
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -19,7 +19,6 @@ import com.neuroid.tracker.events.RESUME_EVENT_CAPTURE
 import com.neuroid.tracker.events.SET_VARIABLE
 import com.neuroid.tracker.events.TOUCH_START
 import com.neuroid.tracker.events.WINDOW_LOAD
-import com.neuroid.tracker.extensions.captureAdvancedDevice
 import com.neuroid.tracker.models.NIDConfiguration
 import com.neuroid.tracker.models.NIDEventModel
 import com.neuroid.tracker.models.NIDRegion
@@ -534,8 +533,6 @@ open class NeuroIDClassUnitTests {
         // mocks, causing a ConcurrentModificationException. Stubbing it makes the coroutine a no-op
         // so cleanup is deterministic.
         mockkStatic("com.neuroid.tracker.extensions.AdvancedDeviceExtensionKt")
-        every { any<NeuroID>().captureAdvancedDevice(any(), any(), any()) } returns Unit
-
         return mockedApplication
     }
 

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIdUnitTest.kt
@@ -1,20 +1,14 @@
 package com.neuroid.tracker
 
-import android.content.Context
 import android.content.res.Resources
 import android.view.View
-import android.view.ViewGroup
 import com.neuroid.tracker.extensions.getIdOrTag
-import com.neuroid.tracker.extensions.getParentsOfView
-import com.neuroid.tracker.utils.NIDLogWrapper
 import com.neuroid.tracker.utils.generateUniqueHexID
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.UUID
 
@@ -107,87 +101,5 @@ class NeuroIdUnitTest {
         val viewReal: View? = null
         val value = viewReal.getIdOrTag()
         assertEquals("no_id", value)
-    }
-
-    /**
-     * This test addresses the ENG-5877
-     */
-    @Test
-    fun testGetParentsOfView_root_view_ViewRootImp() {
-        val context = mockk<Context>()
-        val view = mockk<View>()
-        every { view.id } returns 10
-        val viewGroup = mockk<ViewGroup>()
-        every { viewGroup.parent } returns mockk()
-        every { viewGroup.id } returns 11
-        every { view.parent } returns viewGroup
-        val log = mockk<NIDLogWrapper>()
-        justRun { log.e(any(), any()) }
-        val viewReal = View(context)
-        val label = viewReal.getParentsOfView(0, view, log)
-        // need to use matcher, class.simpleName() returns random numbers in the when mocked
-        val control = "ViewGroup\\\$Subclass\\d+\\/not_a_view"
-        val matcher = control.toRegex()
-        val result = matcher.matches(label)
-        if (!result) {
-            println("testGetParentsOfView_root_view_ViewRootImp failed. Actual: $label should have matched regex: $control`")
-        }
-        assertTrue("testGetParentsOfView_root_view_ViewRootImp", result)
-    }
-
-    @Test
-    fun testGetParentsOfView_root_view_null() {
-        val context = mockk<Context>()
-        val view = mockk<View>()
-        every { view.id } returns 10
-        val viewGroup = mockk<ViewGroup>()
-        every { viewGroup.parent } returns null
-        every { viewGroup.id } returns 10
-        every { view.parent } returns viewGroup
-        val log = mockk<NIDLogWrapper>()
-        justRun { log.e(any(), any()) }
-        val viewReal = View(context)
-        val label = viewReal.getParentsOfView(0, view, log)
-        // need to use matcher, class.simpleName() returns random numbers in the when mocked
-        val control = "ViewGroup\\\$Subclass\\d+\\/not_a_view"
-        val matcher = control.toRegex()
-        val result = matcher.matches(label)
-        if (!result) {
-            println("testGetParentsOfView_root_view_null failed. Actual: $label should have matched regex: $control")
-        }
-        assertTrue("testGetParentsOfView_root_view_null", matcher.matches(label))
-    }
-
-    @Test
-    fun testGetParentsOfView_deep_root_view_greater_than_3() {
-        val context = mockk<Context>()
-        val log = mockk<NIDLogWrapper>()
-        justRun { log.e(any(), any()) }
-        val viewGroup1 = mockk<ViewGroup>()
-        every { viewGroup1.parent } returns mockk()
-        every { viewGroup1.id } returns 10
-        val viewGroup2 = mockk<ViewGroup>()
-        every { viewGroup2.parent } returns viewGroup1
-        every { viewGroup2.id } returns 11
-        val viewGroup3 = mockk<ViewGroup>()
-        every { viewGroup3.parent } returns viewGroup2
-        every { viewGroup3.id } returns 12
-        val viewGroup4 = mockk<ViewGroup>()
-        every { viewGroup4.parent } returns viewGroup3
-        every { viewGroup4.id } returns 13
-        val view = mockk<View>()
-        every { view.parent } returns viewGroup4
-        every { view.id } returns 14
-        val viewReal = View(context)
-        val label = viewReal.getParentsOfView(0, view, log)
-        // need to use matcher, class.simpleName() returns random numbers in the when mocked
-        val control =
-            "ViewGroup\\\$Subclass\\d+\\/ViewGroup\\\$Subclass\\d+\\/ViewGroup\\\$Subclass\\d+\\/"
-        val matcher = control.toRegex()
-        val result = matcher.matches(label)
-        if (!result) {
-            println("testGetParentsOfView_deep_root_view_greater_than_3 failed. Actual: $label should have matched regex: $control")
-        }
-        assertTrue("testGetParentsOfView_deep_root_view_greater_than_3", result)
     }
 }

--- a/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/service/NIDSessionServiceTest.kt
@@ -256,7 +256,7 @@ class NIDSessionServiceTest {
         verify(exactly = 1) {
             mockedDataStore.saveAndClearAllQueuedEvents()
 
-            mockedNeuroID.checkThenCaptureAdvancedDevice(any())
+            mockedNeuroID.checkThenCaptureAdvancedDevice()
         }
     }
 
@@ -1164,7 +1164,7 @@ class NIDSessionServiceTest {
         assert(completionFuncResult?.sessionID == "GoodUID")
 
         verify(exactly = 1) {
-            mockedNeuroID.checkThenCaptureAdvancedDevice(any())
+            mockedNeuroID.checkThenCaptureAdvancedDevice()
             mockedNeuroID.addLinkedSiteID(testSiteID)
         }
 
@@ -1218,7 +1218,7 @@ class NIDSessionServiceTest {
         verify(exactly = 1) {
             mockedConfigService.updateIsSampledStatus(any(), testSiteID)
 
-            mockedNeuroID.checkThenCaptureAdvancedDevice(any())
+            mockedNeuroID.checkThenCaptureAdvancedDevice()
             mockedNeuroID.addLinkedSiteID(testSiteID)
 
             mockedJobServiceManager.startJob(any(), any())
@@ -1284,7 +1284,7 @@ class NIDSessionServiceTest {
 
             mockedConfigService.updateIsSampledStatus(any(), testSiteID)
 
-            mockedNeuroID.checkThenCaptureAdvancedDevice(any())
+            mockedNeuroID.checkThenCaptureAdvancedDevice()
         }
 
         verifyCaptureEvent(

--- a/testapp/src/androidTest/java/com/neuroid/example/EventDispatcher.kt
+++ b/testapp/src/androidTest/java/com/neuroid/example/EventDispatcher.kt
@@ -1,6 +1,7 @@
 package com.neuroid.example
 
 import com.google.gson.Gson
+import com.neuroid.tracker.models.EventBundle
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
@@ -53,7 +54,7 @@ class EventDispatcher(private val eventRecorder: EventRecorder): Dispatcher() {
             url.contains("/c/") -> {
                 val eventModel = Gson().fromJson(
                     BufferedReader(InputStreamReader(request.body.inputStream())),
-                    EventModel::class.java
+                    EventBundle::class.java
                 ) ?: return MockResponse().setResponseCode(200).setBody(collectorResponse)
                 eventRecorder.addEvent(eventModel)
                 MockResponse().setResponseCode(200).setBody(collectorResponse)

--- a/testapp/src/androidTest/java/com/neuroid/example/EventModel.kt
+++ b/testapp/src/androidTest/java/com/neuroid/example/EventModel.kt
@@ -1,9 +1,0 @@
-package com.neuroid.example
-
-import com.neuroid.tracker.models.NIDEventModel
-
-data class EventModel(val linkedSiteId: String = "",
-                      val siteId: String = "",
-                      val clientId: String = "",
-                      val identityId: String? = null,
-                      val jsonEvents: List<NIDEventModel>)

--- a/testapp/src/androidTest/java/com/neuroid/example/EventRecorder.kt
+++ b/testapp/src/androidTest/java/com/neuroid/example/EventRecorder.kt
@@ -1,5 +1,6 @@
 package com.neuroid.example
 
+import com.neuroid.tracker.models.EventBundle
 import junit.framework.TestCase.assertTrue
 
 /**
@@ -7,7 +8,7 @@ import junit.framework.TestCase.assertTrue
  * verify them for event integrity.
  */
 class EventRecorder {
-    private val eventBuffer = mutableListOf<EventModel>()
+    private val eventBuffer = mutableListOf<EventBundle>()
 
     data class RecorderComparison(
         val payloadCountExpected: Int,
@@ -28,7 +29,7 @@ class EventRecorder {
         }
     }
 
-    fun addEvent(eventModel: EventModel) {
+    fun addEvent(eventModel: EventBundle) {
         eventBuffer.add(eventModel)
     }
 
@@ -61,7 +62,7 @@ class EventRecorder {
         val sessionEvents = mutableMapOf<String, MutableSet<String>>()
         eventBuffer.forEach { eventModel ->
             val key = eventModel.identityId.orEmpty().ifBlank { eventModel.clientId }
-            val types = sessionEvents.getOrPut(key) { mutableSetOf() }
+            val types = sessionEvents.getOrPut(key ?: "") { mutableSetOf() }
             eventModel.jsonEvents.forEach { types.add(it.type) }
         }
         return sessionEvents

--- a/testapp/src/androidTest/java/com/neuroid/example/NIDTestInstrumentationRunner.kt
+++ b/testapp/src/androidTest/java/com/neuroid/example/NIDTestInstrumentationRunner.kt
@@ -8,6 +8,7 @@ import com.neuroid.tracker.NeuroID
 import io.mockk.every
 import io.mockk.mockk
 import com.fingerprintjs.android.fpjs_pro.Error
+import com.neuroid.tracker.models.EventBundle
 
 class NIDTestInstrumentationRunner  : AndroidJUnitRunner() {
     private val gson = Gson()
@@ -41,7 +42,7 @@ class NIDTestInstrumentationRunner  : AndroidJUnitRunner() {
         NeuroID.fpjsClientOverride = getMockedFPJSClient("test-visitor-id", null, null)
         NeuroID.outboundPayloadObserver = { payload ->
             runCatching {
-                gson.fromJson(payload, EventModel::class.java)
+                gson.fromJson(payload, EventBundle::class.java)
             }.getOrNull()?.let { eventModel ->
                 NIDTestInstrumentation.attemptedRecorder.addEvent(eventModel)
             }


### PR DESCRIPTION
Cleanup and simplify D+N Service to reduce complexity and timing.

Also adds an explicit `EventBundle` class.

Removes unused `View.getParentsOfView` and `View.getParents` functions.

[ENG-12101]

[ENG-12101]: https://neuro-id.atlassian.net/browse/ENG-12101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ