### PR TITLE
[ENG-12064] Update StartSessionResult with identityId

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/models/SessionStartResult.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/models/SessionStartResult.kt
@@ -2,5 +2,11 @@ package com.neuroid.tracker.models
 
 data class SessionStartResult(
     var started: Boolean,
-    var sessionID: String,
-)
+    var identityId: String,
+) {
+    @Deprecated(
+        "sessionID is deprecated",
+        ReplaceWith("identityId"),
+    )
+    var sessionID: String = identityId
+}

--- a/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
+++ b/NeuroID/src/test/java/com/neuroid/tracker/NeuroIDClassUnitTests.kt
@@ -2528,7 +2528,7 @@ open class NeuroIDClassUnitTests {
     @Test
     fun test_startSession_withSessionID_completionInvokedWithSuccess() {
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "session-abc")
+        val expectedResult = SessionStartResult(started = true, identityId = "session-abc")
         every { mockedSessionService.startSession(null, "session-abc", any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2547,7 +2547,7 @@ open class NeuroIDClassUnitTests {
     @Test
     fun test_startSession_withNullSessionID_completionInvoked() {
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "generated-id")
+        val expectedResult = SessionStartResult(started = true, identityId = "generated-id")
         every { mockedSessionService.startSession(null, null, any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2566,7 +2566,7 @@ open class NeuroIDClassUnitTests {
     @Test
     fun test_startSession_failure_completionInvokedWithFalse() {
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = false, sessionID = "")
+        val expectedResult = SessionStartResult(started = false, identityId = "")
         every { mockedSessionService.startSession(null, any(), any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2586,7 +2586,7 @@ open class NeuroIDClassUnitTests {
     @Test
     fun test_startAppFlow_withUserID_completionInvokedWithSuccess() {
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "flow-session-1")
+        val expectedResult = SessionStartResult(started = true, identityId = "flow-session-1")
         every { mockedSessionService.startAppFlow("site-123", "user-abc", any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2605,7 +2605,7 @@ open class NeuroIDClassUnitTests {
     @Test
     fun test_startAppFlow_withNullUserID_completionInvoked() {
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "flow-session-2")
+        val expectedResult = SessionStartResult(started = true, identityId = "flow-session-2")
         every { mockedSessionService.startAppFlow("site-xyz", null, any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2624,7 +2624,7 @@ open class NeuroIDClassUnitTests {
     @Test
     fun test_startAppFlow_failure_completionInvokedWithFalse() {
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = false, sessionID = "")
+        val expectedResult = SessionStartResult(started = false, identityId = "")
         every { mockedSessionService.startAppFlow(any(), any(), any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2662,7 +2662,7 @@ open class NeuroIDClassUnitTests {
     fun test_startSession_noArgs_defaultCompletion() {
         // Exercises: startSession() — both sessionID and completion use defaults
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "auto-id")
+        val expectedResult = SessionStartResult(started = true, identityId = "auto-id")
         every { mockedSessionService.startSession(null, null, any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2679,7 +2679,7 @@ open class NeuroIDClassUnitTests {
     fun test_startSession_withSessionID_defaultCompletion() {
         // Exercises: startSession(sessionID = "id") — completion uses default {}
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "given-id")
+        val expectedResult = SessionStartResult(started = true, identityId = "given-id")
         every { mockedSessionService.startSession(null, "given-id", any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)
@@ -2716,7 +2716,7 @@ open class NeuroIDClassUnitTests {
     fun test_startAppFlow_withSiteIDOnly_defaultCompletion() {
         // Exercises: startAppFlow(siteID = "site") — userID and completion use defaults
         val mockedSessionService = getMockedSessionService()
-        val expectedResult = SessionStartResult(started = true, sessionID = "flow-default")
+        val expectedResult = SessionStartResult(started = true, identityId = "flow-default")
         every { mockedSessionService.startAppFlow("site-default", null, any()) } answers {
             val completion = thirdArg<(SessionStartResult) -> Unit>()
             completion(expectedResult)


### PR DESCRIPTION
Updates `StartSessionResult` with a new property `identityId` and marks the `sessionID` property as deprecated for backwards compatibility.

[ENG-12064]

[ENG-12064]: https://neuro-id.atlassian.net/browse/ENG-12064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ