### PR TITLE
[ENG-12101] Update onStart listener completion to only run once

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/callbacks/ProcessDeviceLifecycleObserver.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/callbacks/ProcessDeviceLifecycleObserver.kt
@@ -19,6 +19,7 @@ internal class ProcessDeviceLifecycleObserver(
     var started: Boolean = false
 
     override fun onStart(owner: LifecycleOwner) {
+        // Restrict the following to only run the first time the app enters the foreground
         if (started) {
             return
         }

--- a/NeuroID/src/main/java/com/neuroid/tracker/callbacks/ProcessDeviceLifecycleObserver.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/callbacks/ProcessDeviceLifecycleObserver.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.events.LOG
-import com.neuroid.tracker.utils.NIDLog
 
 /**
  *
@@ -17,7 +16,6 @@ import com.neuroid.tracker.utils.NIDLog
 internal class ProcessDeviceLifecycleObserver(
     private val neuroID: NeuroID,
 ) : DefaultLifecycleObserver {
-
     var started: Boolean = false
 
     override fun onStart(owner: LifecycleOwner) {
@@ -25,7 +23,12 @@ internal class ProcessDeviceLifecycleObserver(
             return
         }
 
-        neuroID.captureEvent(queuedEvent = true, type = LOG, m = "isAdvancedDevice setting (onStart): ${neuroID.isAdvancedDevice}", level = "INFO")
+        neuroID.captureEvent(
+            queuedEvent = true,
+            type = LOG,
+            m = "isAdvancedDevice setting (onStart): ${neuroID.isAdvancedDevice}",
+            level = "INFO",
+        )
 
         if (neuroID.isAdvancedDevice) {
             neuroID.checkThenCaptureAdvancedDevice()

--- a/NeuroID/src/main/java/com/neuroid/tracker/callbacks/ProcessDeviceLifecycleObserver.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/callbacks/ProcessDeviceLifecycleObserver.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.events.LOG
+import com.neuroid.tracker.utils.NIDLog
 
 /**
  *
@@ -16,12 +17,23 @@ import com.neuroid.tracker.events.LOG
 internal class ProcessDeviceLifecycleObserver(
     private val neuroID: NeuroID,
 ) : DefaultLifecycleObserver {
+
+    var started: Boolean = false
+
     override fun onStart(owner: LifecycleOwner) {
-        neuroID.captureEvent(type = LOG, m = "isAdvancedDevice setting (onStart): ${neuroID.isAdvancedDevice}", level = "INFO")
+        if (started) {
+            return
+        }
+
+        neuroID.captureEvent(queuedEvent = true, type = LOG, m = "isAdvancedDevice setting (onStart): ${neuroID.isAdvancedDevice}", level = "INFO")
+
         if (neuroID.isAdvancedDevice) {
             neuroID.checkThenCaptureAdvancedDevice()
         }
+
         neuroID.captureApplicationMetaData()
         neuroID.configService.retrieveOrRefreshCache(neuroID)
+
+        started = true
     }
 }


### PR DESCRIPTION
Adds a check in the processor lifecycle listener to only run it's completion handler the first time the app enters the foreground.

[ENG-12101]

[ENG-12101]: https://neuro-id.atlassian.net/browse/ENG-12101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ