### PR TITLE
ENG-11313 add support for using region prefix before path 

### DIFF
--- a/NeuroID/src/main/java/com/neuroid/tracker/service/NIDApiService.kt
+++ b/NeuroID/src/main/java/com/neuroid/tracker/service/NIDApiService.kt
@@ -10,13 +10,13 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface NIDApiService {
-    @POST("/c/{key}")
+    @POST("c/{key}")
     fun sendEvents(
         @Body requestBody: RequestBody,
         @Path("key") key: String,
     ): Call<ResponseBody>
 
-    @GET("/mobile/{key}.json")
+    @GET("mobile/{key}.json")
     fun getConfig(
         @Path("key") key: String,
     ): Call<NIDRemoteConfig>


### PR DESCRIPTION
Add support for using region prefix before path. See example below. 

```
usWest2(
        fpjsProdDomain = "https://advanced.neuro-id.com",
        fpjsPrimaryDomain = "https://dn.neuroid.cloud/iynlfqcb0t",
        productionEndpoint = "https://edge.neuroid.cloud/usw2/",
        productionScriptsEndpoint = "https://scripts.neuro-id.com/"
    ),
```

which will result in: 
```
https://edge.neuroid.cloud/usw2/c/key_live_MwC5DQNYzRsRhnnYjvz1fJtp
```
when the region is set to `usWest2`

Removing the leading `/` from the paths in the NIDApiService interface will allow adding partial paths in the base URL that is specified in Region endpoints. If a path in the API service interface contains a leading `/`, retrofit will remove everything after the first `/` in the base path (the region will be gone) and the path in the APIService will be appended to the modified base URL.  Not having a leading `/` in the path in the API service interface will tell retrofit to keep the entire base url allowing the region to be kept. 
